### PR TITLE
feat(mcp): serve the Docker MCP Gateway over streamable HTTP for Gemini Spark

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -30,8 +30,8 @@
       "url": "https://docs.mcp.cloudflare.com/sse"
     },
     "docker-remote": {
-      "type": "sse",
-      "url": "https://docker-mcp.rainforest.tools/sse"
+      "type": "http",
+      "url": "https://docker-mcp.rainforest.tools/mcp"
     }
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -286,7 +286,7 @@ Notion, memory, terraform, …) behind one SSE endpoint, exposed at
 `https://docker-mcp.rainforest.tools` via the Cloudflare Tunnel + OAuth Worker.
 
 **Architecture: the gateway is a launchd host service, NOT a Terraform container.**
-It runs `docker mcp gateway run --profile default --transport sse --port 3101
+It runs `docker mcp gateway run --profile default --transport streaming --port 3101
 --host 0.0.0.0 --allow-unauthenticated`. This is the *managed* gateway — it executes on
 the host, so it reads config from the Docker Desktop `default` profile and secrets from
 the macOS Keychain (via `docker-credential-desktop`). A plain `docker run` container
@@ -298,8 +298,52 @@ plaintext secrets in `~/.docker/mcp/config.yaml`.
 - **Port:** listens on `3101` (host). Tunnel route `docker-mcp-internal` in `locals.tf`
   points at `host.docker.internal:3101`. `--host 0.0.0.0` is required — cloudflared runs
   in the K8s cluster and reaches the host over the bridge gateway, not loopback.
-- **Restart / apply config changes:** `launchctl kickstart -k gui/$(id -u)/com.homelab.docker-mcp-gateway`
+- **Restart after a profile/Keychain change:** `launchctl kickstart -k gui/$(id -u)/com.homelab.docker-mcp-gateway`
+- **Reload after editing the plist:** `kickstart` does **not** re-read the plist from
+  disk — it restarts from launchd's in-memory job definition, so the gateway keeps
+  running the old arguments while appearing to succeed. Use:
+  ```bash
+  launchctl bootout gui/$(id -u)/com.homelab.docker-mcp-gateway 2>/dev/null
+  launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.homelab.docker-mcp-gateway.plist
+  ```
+  Then confirm with `ps -o command= -p "$(pgrep -f 'mcp gateway run' | head -1)"`.
 - **Logs:** `~/Library/Logs/docker-mcp-gateway.log`
+
+### Transport: streamable HTTP only
+
+The gateway serves **streamable HTTP at `/mcp`**. `docker mcp gateway run
+--transport` takes a **single** value (`stdio|sse|streaming`) — it is not a
+multiplexer, so SSE and streaming cannot coexist on one process. Clients must use
+`"type": "http"` with the `/mcp` path.
+
+**Gotcha — the redirect makes failures look like successes.** The redirect is
+symmetric: an SSE gateway 307s `/mcp` → `/sse`, and a streaming gateway 307s
+`/sse` → `/mcp`. A stale SSE client therefore does *not* get a clean 404. It
+follows the redirect into a transport it cannot speak and fails obscurely. When
+debugging a client, never read a `307` as "the endpoint works".
+
+**Gotcha — never probe with `"params":{}`.** Gateway v0.43.3 has an upstream bug:
+`telemetry.RecordInitialize` (`pkg/telemetry/telemetry.go:549`) dereferences
+`clientInfo` without a nil check, so an `initialize` with empty params SIGSEGVs
+the gateway process. This was invisible under SSE (the 307 fires before the body
+is parsed) but crashes the streaming server, and `KeepAlive` restarts it — which
+looks exactly like "streaming is broken". Always send a full `protocolVersion` +
+`capabilities` + `clientInfo`. Real clients do. Unauthenticated internet requests
+cannot reach this: the OAuth Worker returns 401 first. LAN access to `:3101` can,
+which is the pre-existing accepted risk of `--allow-unauthenticated`.
+
+**Gemini Spark does not need Protected Resource Metadata.** Spark's custom-MCP
+connector requires streamable HTTP, but *not* RFC 9728 PRM. The OAuth Worker
+returns 404 for `/.well-known/oauth-protected-resource` and omits
+`resource_metadata=` from its 401 challenge, and Spark connects anyway by falling
+back to `/.well-known/oauth-authorization-server` (200) and completing Dynamic
+Client Registration at `/register`. `calibre-mcp.rainforest.tools` is the
+precedent — same Worker, same 0.0.6 library, connected and syncing. Do not
+upgrade `@cloudflare/workers-oauth-provider` on the theory that Spark requires
+it; that was investigated and refuted on 2026-08-01.
+
+**Add to Gemini Spark:** gemini.google.com/apps → Custom apps for Spark → Add a
+custom app → `https://docker-mcp.rainforest.tools/mcp`.
 
 ### Config and secrets (profile + Keychain, never in git)
 
@@ -429,8 +473,8 @@ reads `config.yaml`, not the profile, so it won't see profile-set config — the
    {
      "mcpServers": {
        "docker-remote": {
-         "type": "sse",
-         "url": "https://docker-mcp.yourdomain.com/sse",
+         "type": "http",
+         "url": "https://docker-mcp.yourdomain.com/mcp",
          "headers": {
            "CF-Access-Client-Id": "your-service-token-id",
            "CF-Access-Client-Secret": "your-service-token-secret"
@@ -464,8 +508,8 @@ reads `config.yaml`, not the profile, so it won't see profile-set config — the
 {
   "mcpServers": {
     "docker-local": {
-      "type": "sse",
-      "url": "http://localhost:3101/sse"  // Bypasses Cloudflare entirely
+      "type": "http",
+      "url": "http://localhost:3101/mcp"  // Bypasses Cloudflare entirely
     }
   }
 }
@@ -515,8 +559,8 @@ Use the Terraform-generated credentials for permanent OAuth setup:
 {
   "mcpServers": {
     "docker-remote": {
-      "type": "sse",
-      "url": "https://docker-mcp.rainforest.tools/sse",
+      "type": "http",
+      "url": "https://docker-mcp.rainforest.tools/mcp",
       "oauth": {
         "client_id": "3E4n4MoSYkyIXXBo",
         "client_secret": "jkpYLZKtgGJfi0gT6wKgIqEm8KGBimGt"

--- a/README.md
+++ b/README.md
@@ -235,12 +235,12 @@ The Docker MCP Gateway provides **remote Docker operations** via the Model Conte
 - **Remote Docker Control**: Manage containers from any MCP-compatible client
 - **OAuth Authentication**: Secure access with Cloudflare Zero Trust
 - **132+ Tools**: Includes GitHub, Terraform, Obsidian, Playwright, and Sequential Thinking tools
-- **Multiple Transports**: SSE and HTTP streaming support
+- **Streamable HTTP**: single-transport gateway; `--transport` takes one value, so SSE is not served concurrently
 - **Claude Compatible**: Works with Claude web, desktop, and mobile apps
 
 ### Usage
-1. **OAuth-Protected (Recommended)**: `https://docker-mcp.rainforest.tools/sse`
-2. **Local Development**: `http://localhost:3100/sse` (bypasses authentication)
+1. **OAuth-Protected (Recommended)**: `https://docker-mcp.rainforest.tools/mcp`
+2. **Local Development**: `http://localhost:3101/mcp` (bypasses authentication)
 
 ### OAuth Setup for Docker MCP Gateway (Terraform Approach)
 
@@ -274,7 +274,7 @@ The Docker MCP Gateway provides **remote Docker operations** via the Model Conte
    - Sets up custom domain `docker-mcp.yourdomain.com`
    - Manages configuration through Infrastructure as Code
 
-4. **Access OAuth-protected endpoint**: `https://docker-mcp.yourdomain.com/sse`
+4. **Access OAuth-protected endpoint**: `https://docker-mcp.yourdomain.com/mcp`
 
 #### Manual Setup (Deprecated)
 <details>
@@ -311,7 +311,7 @@ The Terraform deployment automatically creates and configures:
 
 #### Usage After Terraform Deployment
 
-- **OAuth-Protected URL**: `https://docker-mcp.yourdomain.com/sse`
+- **OAuth-Protected URL**: `https://docker-mcp.yourdomain.com/mcp`
 - **Authentication**: Automatic OAuth flow with Cloudflare Access
 - **Configuration**: Centrally managed via `terraform.tfvars`
 

--- a/configs/docker-mcp-gateway/com.homelab.docker-mcp-gateway.plist
+++ b/configs/docker-mcp-gateway/com.homelab.docker-mcp-gateway.plist
@@ -27,6 +27,13 @@
   Secrets live in the Keychain (docker mcp secret set), config in the `default`
   profile (docker mcp profile config default --set). Neither is in this file or
   in git.
+
+  --transport streaming (not sse): Gemini Spark's custom-MCP connector speaks
+  Streamable HTTP only, and modern OAuth 2.1 MCP clients expect it. `--transport`
+  takes a SINGLE value — one process cannot serve both SSE and streaming — so
+  this is a cutover. The gateway now serves /mcp; /sse 307-redirects to it, which
+  means stale SSE clients fail obscurely rather than cleanly. Port 3101 is
+  unchanged, so the Cloudflare Tunnel route needs no edit.
 -->
 <plist version="1.0">
 <dict>
@@ -41,7 +48,7 @@
         <string>--profile</string>
         <string>default</string>
         <string>--transport</string>
-        <string>sse</string>
+        <string>streaming</string>
         <string>--port</string>
         <string>3101</string>
         <string>--host</string>

--- a/docs/superpowers/plans/2026-08-01-gemini-spark-mcp-streaming.md
+++ b/docs/superpowers/plans/2026-08-01-gemini-spark-mcp-streaming.md
@@ -1,0 +1,545 @@
+# Docker MCP Gateway → Streamable HTTP (Gemini Spark) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Switch the launchd-managed Docker MCP Gateway from SSE to streamable HTTP so `docker-mcp.rainforest.tools` can be added as a Gemini Spark custom app.
+
+**Architecture:** One process, one transport. `docker mcp gateway run --transport` accepts exactly one of `stdio|sse|streaming`, so this is a cutover, not an additive change. The port (`3101`) is unchanged, so the Cloudflare Tunnel route and all Terraform stay untouched. The OAuth Worker is **not** modified — `calibre-mcp.rainforest.tools` already proves Spark connects through this exact Worker without Protected Resource Metadata.
+
+**Tech Stack:** macOS launchd (plist), Docker MCP Toolkit CLI, `curl` for verification. No Terraform, no `wrangler`, no npm.
+
+**Spec:** `docs/superpowers/specs/2026-08-01-gemini-spark-mcp-streaming-design.md`
+
+---
+
+## Before you start
+
+**This change will disconnect the `docker-remote` MCP server in your current Claude Code session.** `.mcp.json` declares `"type": "sse"`, and after Task 1 the gateway no longer speaks SSE. Task 3 fixes the config, but the connection only returns after Claude Code reloads MCP servers. If you depend on `MCP_DOCKER` tools mid-plan, finish those first — the plan itself needs only `Bash`, `Read`, and `Edit`.
+
+**Rollback at any point:** revert the plist string, then `launchctl kickstart -k gui/$(id -u)/com.homelab.docker-mcp-gateway`. ~30 seconds.
+
+## File Structure
+
+| File | Responsibility | Change |
+|---|---|---|
+| `configs/docker-mcp-gateway/com.homelab.docker-mcp-gateway.plist` | Source of truth for how the gateway process is launched | `sse` → `streaming`, comment block extended |
+| `~/Library/LaunchAgents/com.homelab.docker-mcp-gateway.plist` | The **live** copy launchd actually reads (not version-controlled) | Overwritten from the repo copy |
+| `.mcp.json` | This repo's MCP client config | `"type"` and `"url"` both change |
+| `CLAUDE.md` | Operational reference for the gateway | 4 refs + 1 new subsection |
+| `README.md` | Public-facing service docs | 5 refs, incl. 2 pre-existing bugs |
+
+**Why the repo plist and the LaunchAgents plist are separate steps:** editing the repo file changes nothing at runtime. launchd reads only `~/Library/LaunchAgents/`. Forgetting the copy is the most likely way to "apply" this change and see nothing happen.
+
+---
+
+### Task 1: Flip the gateway transport
+
+**Files:**
+- Modify: `configs/docker-mcp-gateway/com.homelab.docker-mcp-gateway.plist:44` (and comment block near line 22)
+
+- [ ] **Step 1: Confirm the current state fails the target check**
+
+Run:
+```bash
+curl -s -o /dev/null -w "%{http_code} -> %{redirect_url}\n" -X POST http://localhost:3101/mcp -H 'Content-Type: application/json' -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}' --max-time 8
+```
+
+Expected: `307 -> http://localhost:3101/sse`
+
+This is the defect. If you instead get `200`, the flip has already been applied — skip to Task 2.
+
+- [ ] **Step 2: Change the transport string**
+
+In `configs/docker-mcp-gateway/com.homelab.docker-mcp-gateway.plist`, inside `ProgramArguments`, change line 44:
+
+```xml
+        <string>--transport</string>
+        <string>sse</string>
+```
+
+to:
+
+```xml
+        <string>--transport</string>
+        <string>streaming</string>
+```
+
+Change **only** that one `<string>`. Leave `--profile default`, `--port 3101`, `--host 0.0.0.0`, `--allow-unauthenticated`, and `--watch` exactly as they are.
+
+- [ ] **Step 3: Record why, in the existing comment block**
+
+The plist's header comment explains every non-obvious choice. Append this paragraph immediately before the closing `-->` (after the existing `--allow-unauthenticated` paragraph, around line 28):
+
+```
+  --transport streaming (not sse): Gemini Spark's custom-MCP connector speaks
+  Streamable HTTP only, and modern OAuth 2.1 MCP clients expect it. `--transport`
+  takes a SINGLE value — one process cannot serve both SSE and streaming — so
+  this is a cutover. The gateway now serves /mcp; /sse 307-redirects to it, which
+  means stale SSE clients fail obscurely rather than cleanly. Port 3101 is
+  unchanged, so the Cloudflare Tunnel route needs no edit.
+```
+
+- [ ] **Step 4: Install the plist where launchd actually reads it**
+
+Run:
+```bash
+cp configs/docker-mcp-gateway/com.homelab.docker-mcp-gateway.plist ~/Library/LaunchAgents/com.homelab.docker-mcp-gateway.plist
+```
+
+- [ ] **Step 5: Verify the installed copy really changed**
+
+Run:
+```bash
+grep -A1 -- '--transport' ~/Library/LaunchAgents/com.homelab.docker-mcp-gateway.plist
+```
+
+Expected output contains `<string>streaming</string>`. If it still says `sse`, the copy in Step 4 did not happen — do not continue.
+
+- [ ] **Step 6: Restart the gateway**
+
+Run:
+```bash
+launchctl kickstart -k gui/$(id -u)/com.homelab.docker-mcp-gateway
+```
+
+Produces no output on success.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add configs/docker-mcp-gateway/com.homelab.docker-mcp-gateway.plist
+git commit -m "$(cat <<'EOF'
+feat(mcp): serve the gateway over streamable HTTP
+
+Gemini Spark's custom-MCP connector speaks Streamable HTTP only. The
+gateway ran --transport sse, so /mcp merely 307-redirected to /sse.
+--transport is single-valued, so this is a cutover: /sse now redirects
+to /mcp and stale SSE clients fail obscurely.
+
+Port 3101 is unchanged, so the tunnel route and Terraform are untouched.
+
+Refs: no-ticket
+EOF
+)"
+```
+
+---
+
+### Task 2: Verify the gateway actually serves streamable HTTP
+
+No files change. This task exists because Task 1 can appear to succeed while the gateway silently fails to start — `KeepAlive` will restart it in a crash loop and the port stays bound.
+
+- [ ] **Step 1: Confirm the initialize handshake**
+
+Run:
+```bash
+curl -s -D - -o /dev/null -X POST http://localhost:3101/mcp \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json, text/event-stream' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"probe","version":"1"}}}' \
+  --max-time 20 | grep -iE '^HTTP|^Mcp-Session-Id'
+```
+
+Expected:
+```
+HTTP/1.1 200 OK
+Mcp-Session-Id: <some opaque id>
+```
+
+If you get `307`, the plist copy or the restart did not take effect — revisit Task 1 Steps 4-6.
+
+- [ ] **Step 2: Confirm all servers still load**
+
+A gateway that starts but fails to load its profile will return `200` with an empty tool list. Tool-name collisions also surface here.
+
+Run:
+```bash
+SID=$(curl -s -D - -o /dev/null -X POST http://localhost:3101/mcp -H 'Content-Type: application/json' -H 'Accept: application/json, text/event-stream' -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"p","version":"1"}}}' --max-time 30 | grep -i '^Mcp-Session-Id' | tr -d '\r' | awk '{print $2}')
+curl -s -X POST http://localhost:3101/mcp -H 'Content-Type: application/json' -H 'Accept: application/json, text/event-stream' -H "Mcp-Session-Id: $SID" -d '{"jsonrpc":"2.0","method":"notifications/initialized"}' --max-time 10 >/dev/null
+curl -s -X POST http://localhost:3101/mcp -H 'Content-Type: application/json' -H 'Accept: application/json, text/event-stream' -H "Mcp-Session-Id: $SID" -d '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}' --max-time 60 \
+  | python3 -c "import sys,json;[print('tools:',len(json.loads(l[6:])['result']['tools'])) for l in sys.stdin if l.startswith('data: ')]"
+```
+
+Expected: `tools: 163` (a number near 163 is fine — the count moves as catalog servers change; a count of `0` or an error is a failure).
+
+- [ ] **Step 3: Check the log for startup errors**
+
+Run:
+```bash
+tail -30 ~/Library/Logs/docker-mcp-gateway.log
+```
+
+Expected: no repeated panic/restart lines. A tool-name collision appears here as a hard failure at "loading configuration" — if one appears, disable the duplicate with `docker mcp profile tools default --disable <server>.<tool>` and restart.
+
+- [ ] **Step 4: Confirm the public endpoint still authenticates**
+
+The Worker is untouched, so this must be unchanged from before.
+
+Run:
+```bash
+curl -s -o /dev/null -D - -X POST https://docker-mcp.rainforest.tools/mcp -H 'Content-Type: application/json' -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}' --max-time 15 | grep -iE '^HTTP|www-authenticate'
+```
+
+Expected:
+```
+HTTP/2 401
+www-authenticate: Bearer realm="OAuth", error="invalid_token", error_description="Missing or invalid access token"
+```
+
+A `401` here is **success** — it proves the tunnel reaches the Worker and the Worker is guarding the route.
+
+---
+
+### Task 3: Point this repo's MCP client at `/mcp`
+
+**Files:**
+- Modify: `.mcp.json:33-34`
+
+- [ ] **Step 1: Update both lines**
+
+In `.mcp.json`, change the `docker-remote` block from:
+
+```json
+    "docker-remote": {
+      "type": "sse",
+      "url": "https://docker-mcp.rainforest.tools/sse"
+    }
+```
+
+to:
+
+```json
+    "docker-remote": {
+      "type": "http",
+      "url": "https://docker-mcp.rainforest.tools/mcp"
+    }
+```
+
+Both lines must change. Changing only the URL leaves the client negotiating SSE against a streaming endpoint.
+
+Do **not** touch the `cloudflare-*` entries above it — `https://docs.mcp.cloudflare.com/sse` is a third-party server and is correctly SSE.
+
+- [ ] **Step 2: Verify the JSON is still valid**
+
+Run:
+```bash
+python3 -c "import json;d=json.load(open('.mcp.json'));print(d['mcpServers']['docker-remote'])"
+```
+
+Expected: `{'type': 'http', 'url': 'https://docker-mcp.rainforest.tools/mcp'}`
+
+- [ ] **Step 3: Confirm no stale docker-mcp SSE refs remain in config**
+
+Run:
+```bash
+grep -rn "docker-mcp.rainforest.tools/sse" --include="*.json" . || echo "clean"
+```
+
+Expected: `clean`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .mcp.json
+git commit -m "$(cat <<'EOF'
+fix(mcp): point docker-remote at the streamable HTTP endpoint
+
+The gateway no longer speaks SSE. Both the transport type and the URL
+path change; updating only the URL would leave the client negotiating
+SSE against /mcp.
+
+Refs: no-ticket
+EOF
+)"
+```
+
+---
+
+### Task 4: Update CLAUDE.md
+
+**Files:**
+- Modify: `CLAUDE.md:289`, `CLAUDE.md:432-433`, `CLAUDE.md:468`, `CLAUDE.md:517-518`
+- Modify: `CLAUDE.md` — new subsection after the bullet list ending at line 302
+
+- [ ] **Step 1: Fix the command description at line 289**
+
+Change:
+
+```
+It runs `docker mcp gateway run --profile default --transport sse --port 3101
+```
+
+to:
+
+```
+It runs `docker mcp gateway run --profile default --transport streaming --port 3101
+```
+
+- [ ] **Step 2: Fix the service-token example at lines 432-433**
+
+Change:
+
+```json
+       "docker-remote": {
+         "type": "sse",
+         "url": "https://docker-mcp.yourdomain.com/sse",
+```
+
+to:
+
+```json
+       "docker-remote": {
+         "type": "http",
+         "url": "https://docker-mcp.yourdomain.com/mcp",
+```
+
+- [ ] **Step 3: Fix the local-development example at lines 467-468**
+
+Note the server key here is `docker-local`, not `docker-remote` — do not rename it.
+
+Change:
+
+```json
+    "docker-local": {
+      "type": "sse",
+      "url": "http://localhost:3101/sse"  // Bypasses Cloudflare entirely
+    }
+```
+
+to:
+
+```json
+    "docker-local": {
+      "type": "http",
+      "url": "http://localhost:3101/mcp"  // Bypasses Cloudflare entirely
+    }
+```
+
+Both lines change, same as `.mcp.json` in Task 3.
+
+- [ ] **Step 4: Fix the persistent-OAuth example at lines 517-518**
+
+Change:
+
+```json
+    "docker-remote": {
+      "type": "sse",
+      "url": "https://docker-mcp.rainforest.tools/sse",
+```
+
+to:
+
+```json
+    "docker-remote": {
+      "type": "http",
+      "url": "https://docker-mcp.rainforest.tools/mcp",
+```
+
+- [ ] **Step 5: Add the transport subsection**
+
+Insert immediately after the `- **Logs:**` bullet (line 302) and before `### Config and secrets (profile + Keychain, never in git)`:
+
+```markdown
+### Transport: streamable HTTP only
+
+The gateway serves **streamable HTTP at `/mcp`**. `docker mcp gateway run
+--transport` takes a **single** value (`stdio|sse|streaming`) — it is not a
+multiplexer, so SSE and streaming cannot coexist on one process. Clients must use
+`"type": "http"` with the `/mcp` path.
+
+**Gotcha — the redirect makes failures look like successes.** The redirect is
+symmetric: an SSE gateway 307s `/mcp` → `/sse`, and a streaming gateway 307s
+`/sse` → `/mcp`. A stale SSE client therefore does *not* get a clean 404. It
+follows the redirect into a transport it cannot speak and fails obscurely. When
+debugging a client, never read a `307` as "the endpoint works".
+
+**Gemini Spark does not need Protected Resource Metadata.** Spark's custom-MCP
+connector requires streamable HTTP, but *not* RFC 9728 PRM. The OAuth Worker
+returns 404 for `/.well-known/oauth-protected-resource` and omits
+`resource_metadata=` from its 401 challenge, and Spark connects anyway by falling
+back to `/.well-known/oauth-authorization-server` (200) and completing Dynamic
+Client Registration at `/register`. `calibre-mcp.rainforest.tools` is the
+precedent — same Worker, same 0.0.6 library, connected and syncing. Do not
+upgrade `@cloudflare/workers-oauth-provider` on the theory that Spark requires
+it; that was investigated and refuted on 2026-08-01.
+
+**Add to Gemini Spark:** gemini.google.com/apps → Custom apps for Spark → Add a
+custom app → `https://docker-mcp.rainforest.tools/mcp`.
+```
+
+- [ ] **Step 6: Verify no stale refs remain**
+
+Run:
+```bash
+grep -n "docker-mcp.*\/sse\|localhost:3101/sse\|--transport sse" CLAUDE.md || echo "clean"
+```
+
+Expected: `clean`
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "$(cat <<'EOF'
+docs(mcp): document the streamable-HTTP transport
+
+Updates the three client examples and the gateway command description,
+and adds a Transport subsection recording the single-valued --transport
+constraint, the symmetric-redirect gotcha, and why Spark needs no PRM
+(so the refuted Worker upgrade is not re-derived later).
+
+Refs: no-ticket
+EOF
+)"
+```
+
+---
+
+### Task 5: Update README.md
+
+**Files:**
+- Modify: `README.md:238`, `README.md:242-243`, `README.md:277`, `README.md:314`
+
+Two of these are **pre-existing bugs** unrelated to the transport flip, on lines this task already edits: line 238 claims two transports, and line 243 names port `3100` when the gateway has always listened on `3101`.
+
+- [ ] **Step 1: Correct the transport capability claim at line 238**
+
+Change:
+
+```markdown
+- **Multiple Transports**: SSE and HTTP streaming support
+```
+
+to:
+
+```markdown
+- **Streamable HTTP**: single-transport gateway; `--transport` takes one value, so SSE is not served concurrently
+```
+
+- [ ] **Step 2: Fix both usage URLs at lines 242-243**
+
+Change:
+
+```markdown
+1. **OAuth-Protected (Recommended)**: `https://docker-mcp.rainforest.tools/sse`
+2. **Local Development**: `http://localhost:3100/sse` (bypasses authentication)
+```
+
+to:
+
+```markdown
+1. **OAuth-Protected (Recommended)**: `https://docker-mcp.rainforest.tools/mcp`
+2. **Local Development**: `http://localhost:3101/mcp` (bypasses authentication)
+```
+
+The port correction from `3100` to `3101` is deliberate — `3100` was never right.
+
+- [ ] **Step 3: Fix the endpoint at line 277**
+
+Change:
+
+```markdown
+4. **Access OAuth-protected endpoint**: `https://docker-mcp.yourdomain.com/sse`
+```
+
+to:
+
+```markdown
+4. **Access OAuth-protected endpoint**: `https://docker-mcp.yourdomain.com/mcp`
+```
+
+- [ ] **Step 4: Fix the endpoint at line 314**
+
+Change:
+
+```markdown
+- **OAuth-Protected URL**: `https://docker-mcp.yourdomain.com/sse`
+```
+
+to:
+
+```markdown
+- **OAuth-Protected URL**: `https://docker-mcp.yourdomain.com/mcp`
+```
+
+- [ ] **Step 5: Verify no stale refs remain**
+
+Run:
+```bash
+grep -n "docker-mcp.*\/sse\|localhost:3100" README.md || echo "clean"
+```
+
+Expected: `clean`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add README.md
+git commit -m "$(cat <<'EOF'
+docs(mcp): correct gateway URLs, transport claim, and local port
+
+Points the four documented endpoints at /mcp. Also fixes two pre-existing
+errors on the same lines: the gateway serves one transport, not "SSE and
+HTTP streaming", and local development is port 3101, never 3100.
+
+Refs: no-ticket
+EOF
+)"
+```
+
+---
+
+### Task 6: Reconnect clients and add to Gemini Spark
+
+No files change. These are the end-to-end checks.
+
+- [ ] **Step 1: Repo-wide stale-reference sweep**
+
+Run:
+```bash
+grep -rn "docker-mcp.rainforest.tools/sse\|docker-mcp.yourdomain.com/sse" --include="*.md" --include="*.json" . | grep -v "^./docs/superpowers/" || echo "clean"
+```
+
+Expected: `clean`. Hits under `docs/superpowers/` are historical specs and are excluded deliberately — do not rewrite past design documents.
+
+- [ ] **Step 2: Reconnect `docker-remote` in Claude Code**
+
+Reload MCP servers so the new `.mcp.json` takes effect, then confirm a `MCP_DOCKER` tool resolves. If the server still fails, re-check `.mcp.json` has **both** `"type": "http"` and the `/mcp` path.
+
+- [ ] **Step 3: Add the custom app in Gemini Spark**
+
+In a browser: gemini.google.com/apps → **Custom apps for Spark** → **Add a custom app** → enter:
+
+```
+https://docker-mcp.rainforest.tools/mcp
+```
+
+Complete the GitHub OAuth consent when prompted. This is the same flow `calibre-mcp` already uses.
+
+- [ ] **Step 4: Confirm the connection**
+
+On the Connected Apps page, the new app should show **Connected** with a fresh `Last synced` timestamp, exactly like the `Calibre Mcp` card. Click **More details** to confirm it lists available actions.
+
+If Spark reports a failure, capture the exact message — the likeliest causes are a typo in the URL path and an incomplete OAuth consent, in that order. The gateway side is already proven by Task 2.
+
+---
+
+## Rollback
+
+If anything in Tasks 1-2 misbehaves:
+
+```bash
+git revert --no-edit HEAD
+cp configs/docker-mcp-gateway/com.homelab.docker-mcp-gateway.plist ~/Library/LaunchAgents/com.homelab.docker-mcp-gateway.plist
+launchctl kickstart -k gui/$(id -u)/com.homelab.docker-mcp-gateway
+```
+
+Then confirm SSE is back:
+
+```bash
+curl -s -o /dev/null -w "%{http_code} %{content_type}\n" http://localhost:3101/sse --max-time 5
+```
+
+Expected: `200 text/event-stream`
+
+Remember to restore `.mcp.json` to `"type": "sse"` / `/sse` if Task 3 was already committed.

--- a/docs/superpowers/plans/2026-08-01-gemini-spark-mcp-streaming.md
+++ b/docs/superpowers/plans/2026-08-01-gemini-spark-mcp-streaming.md
@@ -41,12 +41,26 @@
 
 Run:
 ```bash
-curl -s -o /dev/null -w "%{http_code} -> %{redirect_url}\n" -X POST http://localhost:3101/mcp -H 'Content-Type: application/json' -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}' --max-time 8
+curl -s -o /dev/null -w "%{http_code} -> %{redirect_url}\n" -X POST http://localhost:3101/mcp \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json, text/event-stream' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"probe","version":"1"}}}' \
+  --max-time 8
 ```
 
 Expected: `307 -> http://localhost:3101/sse`
 
 This is the defect. If you instead get `200`, the flip has already been applied — skip to Task 2.
+
+> **Always send a complete `initialize` — never `"params":{}`.**
+> Gateway v0.43.3 has an upstream bug: `telemetry.RecordInitialize`
+> (`pkg/telemetry/telemetry.go:549`) dereferences `clientInfo` without a nil
+> check, so an `initialize` with empty params **SIGSEGVs the gateway process**.
+> Under SSE this is invisible (the request 307s before it is ever parsed); under
+> streaming it is parsed and kills the process, which `KeepAlive` then restarts —
+> looking exactly like "streaming transport is broken". It is not. Real clients
+> (Claude Code, Gemini Spark) always send `clientInfo`. Reproduced and confirmed
+> 2026-08-01. Every curl in this plan sends full params for this reason.
 
 - [ ] **Step 2: Change the transport string**
 
@@ -95,14 +109,34 @@ grep -A1 -- '--transport' ~/Library/LaunchAgents/com.homelab.docker-mcp-gateway.
 
 Expected output contains `<string>streaming</string>`. If it still says `sse`, the copy in Step 4 did not happen — do not continue.
 
-- [ ] **Step 6: Restart the gateway**
+- [ ] **Step 6: Reload the gateway (NOT `kickstart`)**
 
 Run:
 ```bash
-launchctl kickstart -k gui/$(id -u)/com.homelab.docker-mcp-gateway
+launchctl bootout gui/$(id -u)/com.homelab.docker-mcp-gateway 2>/dev/null
+launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.homelab.docker-mcp-gateway.plist
 ```
 
 Produces no output on success.
+
+> **`launchctl kickstart -k` will NOT work here.** It restarts the process from
+> launchd's already-loaded, in-memory job definition — it does not re-read the
+> plist from disk. After a `kickstart`, the gateway silently keeps running the
+> **old** `--transport sse` while reporting success, which is indistinguishable
+> from the change having worked. `bootout` + `bootstrap` is the correct sequence
+> when the plist file itself changed. (`kickstart -k` remains fine for restarting
+> after a *profile or Keychain* change, where the plist is unchanged — which is
+> why CLAUDE.md documents it; Task 4 clarifies that distinction.)
+
+- [ ] **Step 6b: Prove the running process actually picked up the new flag**
+
+Run:
+```bash
+ps -o command= -p "$(pgrep -f 'docker-mcp-gateway|mcp gateway run' | head -1)" | tr ' ' '\n' | grep -A1 -- '--transport'
+```
+
+Expected: `--transport` followed by `streaming`. If it says `sse`, Step 6 did not
+take effect — do not continue to Task 2.
 
 - [ ] **Step 7: Commit**
 
@@ -335,6 +369,29 @@ to:
       "url": "https://docker-mcp.rainforest.tools/mcp",
 ```
 
+- [ ] **Step 4b: Correct the restart instruction at line 300**
+
+CLAUDE.md currently says:
+
+```markdown
+- **Restart / apply config changes:** `launchctl kickstart -k gui/$(id -u)/com.homelab.docker-mcp-gateway`
+```
+
+That is right for profile/Keychain changes but **wrong for plist changes**, and the
+difference is silent. Replace with:
+
+```markdown
+- **Restart after a profile/Keychain change:** `launchctl kickstart -k gui/$(id -u)/com.homelab.docker-mcp-gateway`
+- **Reload after editing the plist:** `kickstart` does **not** re-read the plist from
+  disk — it restarts from launchd's in-memory job definition, so the gateway keeps
+  running the old arguments while appearing to succeed. Use:
+  ```bash
+  launchctl bootout gui/$(id -u)/com.homelab.docker-mcp-gateway 2>/dev/null
+  launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.homelab.docker-mcp-gateway.plist
+  ```
+  Then confirm with `ps -o command= -p "$(pgrep -f 'mcp gateway run' | head -1)"`.
+```
+
 - [ ] **Step 5: Add the transport subsection**
 
 Insert immediately after the `- **Logs:**` bullet (line 302) and before `### Config and secrets (profile + Keychain, never in git)`:
@@ -531,8 +588,12 @@ If anything in Tasks 1-2 misbehaves:
 ```bash
 git revert --no-edit HEAD
 cp configs/docker-mcp-gateway/com.homelab.docker-mcp-gateway.plist ~/Library/LaunchAgents/com.homelab.docker-mcp-gateway.plist
-launchctl kickstart -k gui/$(id -u)/com.homelab.docker-mcp-gateway
+launchctl bootout gui/$(id -u)/com.homelab.docker-mcp-gateway 2>/dev/null
+launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.homelab.docker-mcp-gateway.plist
 ```
+
+`bootout` + `bootstrap`, not `kickstart` — the plist file changed, so launchd must
+re-read it from disk.
 
 Then confirm SSE is back:
 

--- a/docs/superpowers/specs/2026-08-01-gemini-spark-mcp-streaming-design.md
+++ b/docs/superpowers/specs/2026-08-01-gemini-spark-mcp-streaming-design.md
@@ -1,16 +1,29 @@
 # Wiring the Docker MCP Gateway to Gemini Spark (SSE → Streamable HTTP)
 
 **Date:** 2026-08-01
-**Status:** DESIGN — approved, not yet implemented.
+**Status:** DESIGN — approved. **Revised after live verification: scope reduced to one change.**
 **Goal:** Make `docker-mcp.rainforest.tools` connectable as a Gemini Spark custom app.
 **Verified against:** the live stack on 2026-08-01 — running launchd gateway (pid 25711,
-`:3101`), the deployed OAuth Worker, and worktree `relaxed-cannon-823fd0` at `ed751ba`.
+`:3101`), the deployed OAuth Worker, the operator's Gemini Connected Apps page, and worktree
+`relaxed-cannon-823fd0` at `ed751ba`.
+
+## Revision note (read first)
+
+The first draft of this design identified **three** gaps and planned a risky
+`@cloudflare/workers-oauth-provider` upgrade to close one of them. Live verification refuted
+that gap and closed another. **Only the transport gap is real.**
+
+The decisive evidence: `calibre-mcp.rainforest.tools` is **already connected to Gemini Spark
+and syncing** (modal reads `Connected`, `Last synced: 8/1/2026, 2:42:51 PM`) while running the
+*same* OAuth Worker, the *same* `0.0.6` library, and serving *no* Protected Resource Metadata.
+It is a working reference implementation on our own infrastructure.
+
+Scope is therefore one plist string plus documentation. The Worker is not touched.
 
 ## Why this work exists
 
 Gemini Spark accepts custom MCP servers by URL under **Connected Apps → Custom apps for
-Spark**. Two properties of our gateway currently make it unconnectable, and a third is an
-external gate we do not control.
+Spark**. The gateway serves the wrong transport.
 
 ## Findings (measured, not assumed)
 
@@ -20,19 +33,38 @@ Every row below was probed against the live stack, not inferred from documentati
 |---|---|
 | Gateway `/sse` on `localhost:3101` | `200`, `text/event-stream` — works |
 | Gateway `/mcp` on `localhost:3101` | `307 → /sse`, then `400` — **not** streamable HTTP |
-| Worker `/.well-known/oauth-authorization-server` | `200`, advertises `registration_endpoint` (DCR works) |
-| Worker `/.well-known/oauth-protected-resource` | **`404`** |
-| Public `401` challenge on `/sse` and `/mcp` | `WWW-Authenticate: Bearer realm="OAuth"` — **no `resource_metadata=` parameter** |
 | Trial gateway with `--transport streaming` on `:3199` | `200` + `Mcp-Session-Id`, **163 tools** enumerated |
+| Worker `/.well-known/oauth-authorization-server` | `200`, advertises `registration_endpoint` (DCR works) |
+| Worker `/.well-known/oauth-protected-resource` | `404` — **and this turns out not to matter** |
+| Public `401` on `/sse` and `/mcp` | `WWW-Authenticate: Bearer realm="OAuth"`, no `resource_metadata=` |
+| Gemini → Connected Apps → Custom apps for Spark | **present**, with `Add a custom app` |
+| `calibre-mcp.rainforest.tools` in Spark | **Connected**, `Last synced: 8/1/2026, 2:42:51 PM` |
 
-### Gap 1 — transport
+### The reference implementation
+
+`calibre-mcp.rainforest.tools` and `docker-mcp.rainforest.tools` are served by the same OAuth
+Worker (`HOSTNAME_BACKENDS` in `workers/oauth-gateway/src/index.ts` routes `calibre-mcp` to
+`personal-calibre-internal`). Their `/.well-known/oauth-authorization-server` documents are
+byte-identical after hostname normalization, confirming one shared `0.0.6` stack.
+
+| Property | `calibre-mcp` (works in Spark) | `docker-mcp` (target) |
+|---|---|---|
+| OAuth Worker version | `0.0.6` | `0.0.6` (identical) |
+| `/.well-known/oauth-protected-resource` | `404` | `404` |
+| `/.well-known/oauth-authorization-server` | `200` | `200` |
+| `/mcp` unauthenticated | `401`, no `resource_metadata=` | `401`, no `resource_metadata=` |
+| Transport | **streamable HTTP** | **SSE** ← the only difference |
+
+The single controlled variable is transport. That is the whole fix.
+
+### Gap 1 — transport (REAL, the only blocker)
 
 Google's custom-MCP connector supports **Streamable HTTP only**. The gateway runs
 `--transport sse`.
 
 `docker mcp gateway run --transport` takes exactly one of `stdio|sse|streaming`. It is not a
-multiplexer: **one process cannot serve both transports.** This is the constraint that forces
-a cutover rather than an additive change.
+multiplexer: **one process cannot serve both transports.** This is what forces a cutover
+rather than an additive change.
 
 The redirect behaviour is symmetric and worth recording, because it makes failures look like
 successes:
@@ -44,28 +76,28 @@ An old SSE client after the flip therefore does **not** get a clean `404`. It fo
 redirect into a transport it cannot speak and fails obscurely. Expect confusing client-side
 errors, not obvious ones.
 
-### Gap 2 — OAuth 2.1 discovery
+### Gap 2 — OAuth 2.1 PRM (REFUTED, no action)
 
-Spark speaks OAuth 2.1, which discovers the authorization server via RFC 9728 Protected
-Resource Metadata: the `/.well-known/oauth-protected-resource` document plus the
-`resource_metadata=` hint in the `401` challenge. Both are absent.
+The first draft assumed Spark requires RFC 9728 Protected Resource Metadata, and planned a
+`0.0.6 → 0.8.3` library upgrade to provide it.
 
-Root cause is the pinned dependency: `@cloudflare/workers-oauth-provider@^0.0.6` (latest
-`0.8.3`). RFC 9728 support — including path-aware metadata and the `resource_metadata` hint
-in `WWW-Authenticate` — landed in that gap.
+`calibre-mcp` disproves this. It serves **no** PRM (`404`) and a `401` challenge with **no**
+`resource_metadata=` parameter, yet Spark connected to it and syncs successfully. Spark falls
+back to `/.well-known/oauth-authorization-server` — which `docker-mcp` already serves with a
+`200` — and completes Dynamic Client Registration via `/register`.
 
-Dynamic Client Registration itself already works, so once PRM exists Spark should
-self-register without manually provisioned credentials.
+**The Worker is not modified.** This removes the only step capable of taking all remote MCP
+access offline.
 
-### Gap 3 — account eligibility (external, unresolved)
+The upgrade remains worthwhile as independent hygiene (`0.0.6` is far behind `0.8.3`), but it
+is unrelated to Spark and must not be bundled into this change, where a login-flow regression
+would be misattributed to the transport flip.
 
-Google gates this feature on **18+, in the US, personal Google Account** (not Workspace).
-The operator is in Taipei on `contact@rainforest.tools`.
+### Gap 3 — account eligibility (CLOSED)
 
-**This is not fixable from this repo.** Confirm that
-**gemini.google.com/apps → Custom apps for Spark → Add a custom app** is visible before
-expecting a working Spark connection. Gaps 1 and 2 remain worth closing regardless — they are
-correctness fixes for *any* modern OAuth 2.1 MCP client, not Spark-specific hacks.
+Verified directly in the operator's browser: **Connected Apps → Custom apps for Spark** is
+present, with a working `Add a custom app` control and one app already connected. The
+US-only/personal-account gate does not block this account.
 
 ## Blast radius
 
@@ -82,16 +114,17 @@ Nothing else on the machine consumes the SSE endpoint.
 
 **Explicitly unaffected:** `~/.gemini/config/mcp_config.json` runs
 `docker mcp gateway run --profile antigravity` over **stdio**, on a *different profile*. `agy`
-does not touch `:3101` or the SSE URL. Other repos' `.mcp.json` files contain no
-`docker-mcp` reference (`rainforest-monorepo` points at `calibre-mcp`, a separate service).
-Other hits under `.claude/worktrees/` are copies of this repo.
+does not touch `:3101` or the SSE URL. Other repos' `.mcp.json` files contain no `docker-mcp`
+reference (`rainforest-monorepo` points at `calibre-mcp`, a separate service — and one that
+must keep working, since it is the Spark reference implementation). Other hits under
+`.claude/worktrees/` are copies of this repo.
 
 ## Worktree safety
 
 The July gateway spec was authored from a stale worktree and nearly reverted ~26 files of
 in-flight work. That hazard was checked for here and does **not** apply:
 
-- All five target files are byte-identical between this worktree and the main checkout.
+- All target files are byte-identical between this worktree and the main checkout.
 - The worktree is at `ed751ba`, which already contains main's `39b64cd`.
 - The only dirty path in the main checkout is `modules/comfyui/server` (unrelated submodule).
 
@@ -108,79 +141,59 @@ Everything else stays: port `3101`, `--host 0.0.0.0`, `--allow-unauthenticated`,
 `docker-mcp-internal → host.docker.internal:3101` in `locals.tf` needs **no change** and no
 `terraform apply` is required.
 
-Extend the plist's comment block to record why streaming was chosen (Spark requires it; OAuth
-2.1 clients generally expect it), keeping the file's existing convention of explaining
-non-obvious choices inline.
+Extend the plist's comment block to record why streaming was chosen, keeping the file's
+existing convention of explaining non-obvious choices inline.
 
 Deploy: copy to `~/Library/LaunchAgents/`, then
 `launchctl kickstart -k gui/$(id -u)/com.homelab.docker-mcp-gateway`.
 
-### 2. Worker OAuth upgrade
+### 2. Client and documentation updates
 
-**Files:** `workers/oauth-gateway/package.json`, `workers/oauth-gateway/src/index.ts`
+Flip the seven references in the blast-radius table from `/sse` → `/mcp` and
+`"type": "sse"` → `"type": "http"`. Note `.mcp.json` needs **both** lines changed — changing
+only the URL leaves the client still negotiating SSE against a streaming endpoint.
 
-Bump `@cloudflare/workers-oauth-provider` from `^0.0.6` to `^0.8.3` and adapt the
-`new OAuthProvider({...})` construction (`index.ts:75-86`, the file's default export) to the
-current API. This yields
-`/.well-known/oauth-protected-resource` and the `resource_metadata=` hint as library
-built-ins rather than a hand-rolled shim on a pinned old dependency.
+Add a short CLAUDE.md subsection under the existing "Docker MCP Gateway" heading recording:
 
-No routing change is needed: `apiHandlers` already registers `/mcp`. That route is presently a
-dead end only because the *backend* 307s it away — step 1 fixes that, and the route starts
-working with no edit.
+- the gateway serves **streamable HTTP** at `/mcp`
+- `--transport` is single-valued, so SSE and streaming cannot coexist on one process
+- the symmetric-redirect gotcha, so a future reader does not misread a `307` as a working
+  endpoint
+- that Spark needs no PRM, with `calibre-mcp` cited as the precedent — so nobody re-derives
+  the refuted Gap 2 later
 
-`mcpProxyHandler` needs no changes. It forwards method, headers and body verbatim and is
-transport-agnostic; the `X-Forwarded-*` / `X-GitHub-*` header injection and hostname-based
-backend routing are unaffected.
-
-### 3. Client and documentation updates
-
-Flip the six references in the blast-radius table from `/sse` → `/mcp` and
-`"type": "sse"` → `"type": "http"`.
-
-Add a short CLAUDE.md subsection under the existing "Docker MCP Gateway" heading recording
-that the gateway serves **streamable HTTP**, that `--transport` is single-valued, and the
-symmetric-redirect gotcha — so a future reader debugging a client does not misread a `307` as
-a working endpoint.
-
-### 4. Sequencing
-
-Step 1 before step 2, deliberately. The transport flip is trivially reversible and
-independently verifiable; the Worker upgrade touches the auth path guarding *all* remote MCP
-access. Sequencing them separately keeps any failure attributable to one change.
-
-### 5. Verification
+### 3. Verification
 
 Each check gates the next:
 
 1. `curl` `localhost:3101/mcp` initialize → `200` + `Mcp-Session-Id` (transport flip works)
 2. `tools/list` over that session → expect ~163 tools (servers still load; no name collision)
-3. `curl` public `/mcp` unauthenticated → `401` whose `WWW-Authenticate` **contains
-   `resource_metadata=`** (upgrade works)
-4. `curl` public `/.well-known/oauth-protected-resource` → `200` (currently `404`)
-5. **Re-run the GitHub OAuth login end-to-end.** Not optional — the upgrade modifies the auth
-   path, and metadata endpoints returning `200` does not prove the login flow survived.
-6. Reconnect `docker-remote` in Claude Code; confirm tools resolve.
-7. Add `https://docker-mcp.rainforest.tools/mcp` in Gemini Spark (gated on Gap 3).
+3. `curl` public `/mcp` unauthenticated → `401` (Worker untouched, should be unchanged)
+4. Reconnect `docker-remote` in Claude Code with `"type": "http"`; confirm tools resolve
+5. Add `https://docker-mcp.rainforest.tools/mcp` in Gemini Spark → **Add a custom app**,
+   matching the URL shape `calibre-mcp` already uses successfully
+6. Confirm the new app shows `Connected` with a fresh `Last synced` timestamp
 
-### 6. Rollback
+No OAuth login re-test is required, because the Worker is not modified.
 
-- **Gateway:** revert the plist string, `launchctl kickstart -k`. ~30 seconds.
-- **Worker:** `git revert`, `wrangler deploy`. ~30 seconds.
+### 4. Rollback
 
-Both are independent, matching the sequencing rationale.
+Revert the plist string and `launchctl kickstart -k`. ~30 seconds, single file, no deploy.
 
 ## Risks
 
 | Risk | Severity | Mitigation |
 |---|---|---|
-| Worker upgrade breaks the GitHub login flow, taking `docker-mcp.rainforest.tools` offline | High | Sequenced second, verified independently, fast `git revert` + redeploy |
 | A forgotten SSE client fails obscurely via the `307` rather than a clean error | Low | Inventory is complete and small; gotcha documented in CLAUDE.md |
-| Spark rejects the server for an undocumented reason (no client-side logs) | Medium | Steps 1–6 verify our side against the spec independently of Spark |
-| Gap 3 blocks the connection entirely | Medium | External; unblocks nothing else — steps 1–3 remain correct regardless |
+| Streaming gateway behaves differently under sustained load than in the `:3199` trial | Low | Trial enumerated all 163 tools cleanly; rollback is one string |
+| Spark rejects the server for an undocumented reason | Low | `calibre-mcp` proves the exact Worker + DCR + URL shape already works |
+
+Removing the Worker upgrade eliminated the only High-severity risk in the original design.
 
 ## Out of scope
 
-- Migrating other MCP endpoints (`calibre-mcp`, `obsidian`) to streamable HTTP.
+- Upgrading `@cloudflare/workers-oauth-provider` (worthwhile hygiene; unrelated to Spark —
+  track separately so a login regression is never misattributed to this change).
+- Migrating other MCP endpoints (`obsidian`) to streamable HTTP.
 - Changing Zero Trust or tunnel topology.
 - Adding new MCP servers to the `default` profile.

--- a/docs/superpowers/specs/2026-08-01-gemini-spark-mcp-streaming-design.md
+++ b/docs/superpowers/specs/2026-08-01-gemini-spark-mcp-streaming-design.md
@@ -1,0 +1,186 @@
+# Wiring the Docker MCP Gateway to Gemini Spark (SSE → Streamable HTTP)
+
+**Date:** 2026-08-01
+**Status:** DESIGN — approved, not yet implemented.
+**Goal:** Make `docker-mcp.rainforest.tools` connectable as a Gemini Spark custom app.
+**Verified against:** the live stack on 2026-08-01 — running launchd gateway (pid 25711,
+`:3101`), the deployed OAuth Worker, and worktree `relaxed-cannon-823fd0` at `ed751ba`.
+
+## Why this work exists
+
+Gemini Spark accepts custom MCP servers by URL under **Connected Apps → Custom apps for
+Spark**. Two properties of our gateway currently make it unconnectable, and a third is an
+external gate we do not control.
+
+## Findings (measured, not assumed)
+
+Every row below was probed against the live stack, not inferred from documentation.
+
+| Check | Result |
+|---|---|
+| Gateway `/sse` on `localhost:3101` | `200`, `text/event-stream` — works |
+| Gateway `/mcp` on `localhost:3101` | `307 → /sse`, then `400` — **not** streamable HTTP |
+| Worker `/.well-known/oauth-authorization-server` | `200`, advertises `registration_endpoint` (DCR works) |
+| Worker `/.well-known/oauth-protected-resource` | **`404`** |
+| Public `401` challenge on `/sse` and `/mcp` | `WWW-Authenticate: Bearer realm="OAuth"` — **no `resource_metadata=` parameter** |
+| Trial gateway with `--transport streaming` on `:3199` | `200` + `Mcp-Session-Id`, **163 tools** enumerated |
+
+### Gap 1 — transport
+
+Google's custom-MCP connector supports **Streamable HTTP only**. The gateway runs
+`--transport sse`.
+
+`docker mcp gateway run --transport` takes exactly one of `stdio|sse|streaming`. It is not a
+multiplexer: **one process cannot serve both transports.** This is the constraint that forces
+a cutover rather than an additive change.
+
+The redirect behaviour is symmetric and worth recording, because it makes failures look like
+successes:
+
+- SSE gateway: `/mcp` → `307` → `/sse`
+- Streaming gateway: `/sse` → `307` → `/mcp`
+
+An old SSE client after the flip therefore does **not** get a clean `404`. It follows a
+redirect into a transport it cannot speak and fails obscurely. Expect confusing client-side
+errors, not obvious ones.
+
+### Gap 2 — OAuth 2.1 discovery
+
+Spark speaks OAuth 2.1, which discovers the authorization server via RFC 9728 Protected
+Resource Metadata: the `/.well-known/oauth-protected-resource` document plus the
+`resource_metadata=` hint in the `401` challenge. Both are absent.
+
+Root cause is the pinned dependency: `@cloudflare/workers-oauth-provider@^0.0.6` (latest
+`0.8.3`). RFC 9728 support — including path-aware metadata and the `resource_metadata` hint
+in `WWW-Authenticate` — landed in that gap.
+
+Dynamic Client Registration itself already works, so once PRM exists Spark should
+self-register without manually provisioned credentials.
+
+### Gap 3 — account eligibility (external, unresolved)
+
+Google gates this feature on **18+, in the US, personal Google Account** (not Workspace).
+The operator is in Taipei on `contact@rainforest.tools`.
+
+**This is not fixable from this repo.** Confirm that
+**gemini.google.com/apps → Custom apps for Spark → Add a custom app** is visible before
+expecting a working Spark connection. Gaps 1 and 2 remain worth closing regardless — they are
+correctness fixes for *any* modern OAuth 2.1 MCP client, not Spark-specific hacks.
+
+## Blast radius
+
+Complete inventory of SSE consumers, from searching `~/Repositories`, `~/.claude.json`,
+Claude Desktop config, `~/.gemini`, and `~/.codex`:
+
+| File | References |
+|---|---|
+| `.mcp.json` | 2 — lines 33 (`"type": "sse"`) and 34 (`/sse` URL) |
+| `CLAUDE.md` | 2 — lines 433, 519 |
+| `README.md` | 3 — lines 242, 277, 314 |
+
+Nothing else on the machine consumes the SSE endpoint.
+
+**Explicitly unaffected:** `~/.gemini/config/mcp_config.json` runs
+`docker mcp gateway run --profile antigravity` over **stdio**, on a *different profile*. `agy`
+does not touch `:3101` or the SSE URL. Other repos' `.mcp.json` files contain no
+`docker-mcp` reference (`rainforest-monorepo` points at `calibre-mcp`, a separate service).
+Other hits under `.claude/worktrees/` are copies of this repo.
+
+## Worktree safety
+
+The July gateway spec was authored from a stale worktree and nearly reverted ~26 files of
+in-flight work. That hazard was checked for here and does **not** apply:
+
+- All five target files are byte-identical between this worktree and the main checkout.
+- The worktree is at `ed751ba`, which already contains main's `39b64cd`.
+- The only dirty path in the main checkout is `modules/comfyui/server` (unrelated submodule).
+
+## Design
+
+### 1. Gateway transport flip
+
+**File:** `configs/docker-mcp-gateway/com.homelab.docker-mcp-gateway.plist`
+
+Change the single `<string>sse</string>` in `ProgramArguments` to `<string>streaming</string>`.
+
+Everything else stays: port `3101`, `--host 0.0.0.0`, `--allow-unauthenticated`, `--watch`,
+`--profile default`. Because the port is unchanged, the tunnel route
+`docker-mcp-internal → host.docker.internal:3101` in `locals.tf` needs **no change** and no
+`terraform apply` is required.
+
+Extend the plist's comment block to record why streaming was chosen (Spark requires it; OAuth
+2.1 clients generally expect it), keeping the file's existing convention of explaining
+non-obvious choices inline.
+
+Deploy: copy to `~/Library/LaunchAgents/`, then
+`launchctl kickstart -k gui/$(id -u)/com.homelab.docker-mcp-gateway`.
+
+### 2. Worker OAuth upgrade
+
+**Files:** `workers/oauth-gateway/package.json`, `workers/oauth-gateway/src/index.ts`
+
+Bump `@cloudflare/workers-oauth-provider` from `^0.0.6` to `^0.8.3` and adapt the
+`new OAuthProvider({...})` construction (`index.ts:75-86`, the file's default export) to the
+current API. This yields
+`/.well-known/oauth-protected-resource` and the `resource_metadata=` hint as library
+built-ins rather than a hand-rolled shim on a pinned old dependency.
+
+No routing change is needed: `apiHandlers` already registers `/mcp`. That route is presently a
+dead end only because the *backend* 307s it away — step 1 fixes that, and the route starts
+working with no edit.
+
+`mcpProxyHandler` needs no changes. It forwards method, headers and body verbatim and is
+transport-agnostic; the `X-Forwarded-*` / `X-GitHub-*` header injection and hostname-based
+backend routing are unaffected.
+
+### 3. Client and documentation updates
+
+Flip the six references in the blast-radius table from `/sse` → `/mcp` and
+`"type": "sse"` → `"type": "http"`.
+
+Add a short CLAUDE.md subsection under the existing "Docker MCP Gateway" heading recording
+that the gateway serves **streamable HTTP**, that `--transport` is single-valued, and the
+symmetric-redirect gotcha — so a future reader debugging a client does not misread a `307` as
+a working endpoint.
+
+### 4. Sequencing
+
+Step 1 before step 2, deliberately. The transport flip is trivially reversible and
+independently verifiable; the Worker upgrade touches the auth path guarding *all* remote MCP
+access. Sequencing them separately keeps any failure attributable to one change.
+
+### 5. Verification
+
+Each check gates the next:
+
+1. `curl` `localhost:3101/mcp` initialize → `200` + `Mcp-Session-Id` (transport flip works)
+2. `tools/list` over that session → expect ~163 tools (servers still load; no name collision)
+3. `curl` public `/mcp` unauthenticated → `401` whose `WWW-Authenticate` **contains
+   `resource_metadata=`** (upgrade works)
+4. `curl` public `/.well-known/oauth-protected-resource` → `200` (currently `404`)
+5. **Re-run the GitHub OAuth login end-to-end.** Not optional — the upgrade modifies the auth
+   path, and metadata endpoints returning `200` does not prove the login flow survived.
+6. Reconnect `docker-remote` in Claude Code; confirm tools resolve.
+7. Add `https://docker-mcp.rainforest.tools/mcp` in Gemini Spark (gated on Gap 3).
+
+### 6. Rollback
+
+- **Gateway:** revert the plist string, `launchctl kickstart -k`. ~30 seconds.
+- **Worker:** `git revert`, `wrangler deploy`. ~30 seconds.
+
+Both are independent, matching the sequencing rationale.
+
+## Risks
+
+| Risk | Severity | Mitigation |
+|---|---|---|
+| Worker upgrade breaks the GitHub login flow, taking `docker-mcp.rainforest.tools` offline | High | Sequenced second, verified independently, fast `git revert` + redeploy |
+| A forgotten SSE client fails obscurely via the `307` rather than a clean error | Low | Inventory is complete and small; gotcha documented in CLAUDE.md |
+| Spark rejects the server for an undocumented reason (no client-side logs) | Medium | Steps 1–6 verify our side against the spec independently of Spark |
+| Gap 3 blocks the connection entirely | Medium | External; unblocks nothing else — steps 1–3 remain correct regardless |
+
+## Out of scope
+
+- Migrating other MCP endpoints (`calibre-mcp`, `obsidian`) to streamable HTTP.
+- Changing Zero Trust or tunnel topology.
+- Adding new MCP servers to the `default` profile.

--- a/locals.tf
+++ b/locals.tf
@@ -94,6 +94,10 @@ locals {
         service_url = "http://host.docker.internal:3101" # launchd managed gateway (docker mcp gateway run)
         enable_auth = false                              # Auth handled by OAuth Worker layer
         type        = "docker"
+        # The streaming transport's DNS-rebinding guard accepts only localhost/127.0.0.1
+        # as Host. Without this rewrite cloudflared forwards the public hostname and the
+        # gateway answers 403 "invalid Host header" — after OAuth has already succeeded.
+        http_host_header = "localhost:3101"
       }
     },
 

--- a/modules/cloudflare-tunnel/main.tf
+++ b/modules/cloudflare-tunnel/main.tf
@@ -70,10 +70,15 @@ resource "cloudflare_zero_trust_tunnel_cloudflared_config" "homelab" {
         hostname = "${ingress_rule.value.hostname}.${var.domain_suffix}"
         service  = ingress_rule.value.service_url
 
+        # NOTE: this remote (API-managed) tunnel configuration is what cloudflared
+        # actually serves. It overrides the ingress rules in the cloudflared-config
+        # ConfigMap even though the Deployment passes --config, so per-route options
+        # MUST be set here. Editing only the ConfigMap silently has no effect.
         dynamic "origin_request" {
-          for_each = startswith(ingress_rule.value.service_url, "https://") ? [1] : []
+          for_each = startswith(ingress_rule.value.service_url, "https://") || ingress_rule.value.http_host_header != "" ? [1] : []
           content {
-            no_tls_verify = true
+            no_tls_verify    = startswith(ingress_rule.value.service_url, "https://")
+            http_host_header = ingress_rule.value.http_host_header
           }
         }
       }
@@ -90,7 +95,7 @@ resource "cloudflare_zero_trust_tunnel_cloudflared_config" "homelab" {
 resource "cloudflare_record" "services" {
   for_each = {
     for name, config in var.services : name => config
-    if !lookup(config, "internal", false)  # Skip services marked as internal
+    if !lookup(config, "internal", false) # Skip services marked as internal
   }
 
   zone_id = local.zone_id
@@ -269,9 +274,14 @@ data:
 %{for name, config in var.services~}
       - hostname: ${config.hostname}.${var.domain_suffix}
         service: ${config.service_url}
-%{if startswith(config.service_url, "https://")~}
+%{if startswith(config.service_url, "https://") || config.http_host_header != ""~}
         originRequest:
+%{if startswith(config.service_url, "https://")~}
           noTLSVerify: true
+%{endif~}
+%{if config.http_host_header != ""~}
+          httpHostHeader: ${config.http_host_header}
+%{endif~}
 %{endif~}
 %{endfor~}
       - service: http_status:404

--- a/modules/cloudflare-tunnel/variables.tf
+++ b/modules/cloudflare-tunnel/variables.tf
@@ -61,12 +61,16 @@ variable "google_oauth_client_secret" {
 variable "services" {
   description = "Map of services to expose through Cloudflare Tunnel"
   type = map(object({
-    hostname     = string
-    service_url  = string
-    enable_auth  = bool
-    type         = string
+    hostname       = string
+    service_url    = string
+    enable_auth    = bool
+    type           = string
     internal       = optional(bool, false)
     allowed_emails = optional(list(string), [])
+    # Rewrite the Host header sent to the origin. Required by origins that reject
+    # unexpected Host values — e.g. the Docker MCP Gateway's streaming transport,
+    # whose DNS-rebinding guard accepts only localhost/127.0.0.1.
+    http_host_header = optional(string, "")
   }))
   default = {}
 }


### PR DESCRIPTION
## Why

Gemini Spark's custom-MCP connector speaks **Streamable HTTP only**. The gateway ran `--transport sse`, so `docker-mcp.rainforest.tools` could not be added as a Spark custom app.

## What changed

| Area | Change |
|---|---|
| Gateway | `--transport sse` → `streaming` in the launchd plist. Port 3101 unchanged. |
| Tunnel | New optional `http_host_header` per service; set to `localhost:3101` for `docker-mcp-internal`. |
| Clients | `.mcp.json` → `"type": "http"` + `/mcp`. |
| Docs | CLAUDE.md gains a Transport section; README endpoint/port corrections. |

## Verified

- Local `/mcp` → `200` + `Mcp-Session-Id`, **163 tools** enumerated
- Public `/mcp` → `401` (OAuth Worker still guarding; unchanged)
- Running process confirmed via `ps` to carry `--transport streaming`

## Not yet verified

`docker-mcp-internal` still returns `403` until the tunnel config is applied. **This PR is not complete until `terraform apply` runs** — see below.

## Three findings worth keeping

**1. `--transport streaming` enables a DNS-rebinding guard.** It accepts only `localhost`/`127.0.0.1` as `Host`. cloudflared forwards the public hostname, so the gateway answers `403 invalid Host header` — *after* OAuth succeeds, making Spark fail late and opaquely. SSE had no such check, so this arrived with the cutover. Fixed with `httpHostHeader`.

**2. The remote tunnel config overrides the ConfigMap.** cloudflared logs `Updated to new configuration ... version=29` with the API-managed ingress, ignoring `cloudflared-config`'s rules even though the Deployment passes `--config`. A live `kubectl patch` of the ConfigMap provably changed nothing. Per-route options must be set in `cloudflare_zero_trust_tunnel_cloudflared_config`. Both are now kept consistent.

**3. `launchctl kickstart -k` does not reload an edited plist.** It restarts from launchd's in-memory job definition, so the gateway silently keeps its old arguments while reporting success. `bootout` + `bootstrap` is required. CLAUDE.md now distinguishes the two cases.

Also fixes two pre-existing README errors on lines already being edited: the gateway serves one transport (not "SSE and HTTP streaming"), and local dev is port `3101`, never `3100`.

## Apply instructions — read before merging

Run from the **main checkout**, never a worktree. A plan generated from a worktree rewrites `host_path` bind mounts to worktree paths and would force-replace `grafana_alloy` (verified).

Target the single resource. A full apply sweeps in ~22 unrelated pre-existing drift changes (13 `email_policy` updates, `docker_volume_backup` recreate, and others):

```bash
terraform apply -target=module.cloudflare_tunnel.cloudflare_zero_trust_tunnel_cloudflared_config.homelab
```

cloudflared polls remote config, so no pod restart is needed.

Then confirm `403` → `200`:

```bash
curl -s -o /dev/null -w "%{http_code}\n" -X POST https://docker-mcp-internal.rainforest.tools/mcp -H 'Content-Type: application/json' -H 'Accept: application/json, text/event-stream' -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"probe","version":"1"}}}'
```

Never probe with `"params":{}` — gateway v0.43.3 dereferences `clientInfo` without a nil check and SIGSEGVs.

## Rollback

Revert the plist string, then `bootout` + `bootstrap`. The tunnel change is inert without it.

Refs: no-ticket

🤖 Generated with [Claude Code](https://claude.com/claude-code)