### PR TITLE
fix(mcp): relay LAN traffic for containers so grafana tools work

### DIFF
--- a/configs/lan-forwarder/com.homelab.lan-forwarder.plist
+++ b/configs/lan-forwarder/com.homelab.lan-forwarder.plist
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  LAN forwarder — launchd user agent giving Docker containers a route to the Pi.
+
+  The problem: Docker Desktop containers on this Mac cannot reach the LAN.
+  Tailscale and WireGuard hold `default` routes on utun interfaces and container
+  egress does not follow them. Measured: from inside a container,
+  `ping 192.168.0.128` is 100% packet loss and
+  `curl http://192.168.0.128:30080` fails, while the same curl from the host
+  returns 200 over en1.
+
+  This broke the Docker MCP Gateway's `grafana` server, whose container must
+  reach Grafana on the Pi. It reported:
+    list datasources: Get "http://192.168.0.128:30080/api/datasources":
+      dial tcp 192.168.0.128:30080: connect: connection refused
+
+  The fix: containers CAN reach `host.docker.internal`, so the host relays.
+  This agent listens on host port 30080 and forwards to the Pi's 30080. The
+  gateway profile then points at `http://host.docker.internal:30080`, matching
+  the pattern CLAUDE.md already documents for host-side services.
+
+  Port 30080 mirrors the Pi's port on purpose, so the two sides of the relay
+  read the same in config and logs.
+
+  --host 0.0.0.0 equivalent: the script binds 0.0.0.0, which is REQUIRED. A
+  127.0.0.1 bind is not reachable from the Docker Desktop VM.
+
+  If Tailscale/WireGuard routing is ever fixed so containers reach the LAN
+  directly, this agent and the host.docker.internal indirection can both be
+  dropped — set grafana.url back to the Pi's LAN address.
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.homelab.lan-forwarder</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/usr/bin/python3</string>
+        <string>/Users/rainforest/Repositories/rainforest-homelab/configs/lan-forwarder/lan-forwarder.py</string>
+        <string>30080</string>
+        <string>192.168.0.128</string>
+        <string>30080</string>
+    </array>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+        <key>HOME</key>
+        <string>/Users/rainforest</string>
+    </dict>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+    <key>StandardOutPath</key>
+    <string>/Users/rainforest/Library/Logs/homelab-lan-forwarder.log</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/rainforest/Library/Logs/homelab-lan-forwarder.log</string>
+</dict>
+</plist>

--- a/configs/lan-forwarder/lan-forwarder.py
+++ b/configs/lan-forwarder/lan-forwarder.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""TCP forwarder giving Docker containers a route to LAN services.
+
+Why this exists
+---------------
+Docker Desktop containers on this Mac cannot reach the LAN. Tailscale (and
+WireGuard) hold `default` routes on utun interfaces, and container egress does
+not follow them: from inside a container `ping 192.168.0.128` is 100% loss,
+while the host reaches it fine over en1.
+
+Containers CAN reach `host.docker.internal`. So the host relays: a container
+connects to `host.docker.internal:<local_port>` and this process forwards to
+`<remote_host>:<remote_port>` on the LAN.
+
+This is what makes the Docker MCP Gateway's `grafana` server work — its
+container has to reach Grafana on the Raspberry Pi. Without the relay it gets
+`dial tcp 192.168.0.128:30080: connect: connection refused`.
+
+Usage: lan-forwarder.py <local_port> <remote_host> <remote_port>
+
+Stdlib only, deliberately — this runs under launchd before any venv exists,
+and adding a dependency would make the agent fail to start on a fresh machine.
+"""
+import socket
+import sys
+import threading
+
+BUFSIZE = 65536
+CONNECT_TIMEOUT = 10
+
+
+def pipe(src, dst):
+    """Relay bytes one direction until either side closes."""
+    try:
+        while True:
+            data = src.recv(BUFSIZE)
+            if not data:
+                break
+            dst.sendall(data)
+    except OSError:
+        pass
+    finally:
+        # Shut both halves down so the paired thread also unblocks.
+        for sock in (src, dst):
+            try:
+                sock.shutdown(socket.SHUT_RDWR)
+            except OSError:
+                pass
+
+
+def handle(client, remote_host, remote_port):
+    try:
+        upstream = socket.create_connection(
+            (remote_host, remote_port), timeout=CONNECT_TIMEOUT
+        )
+    except OSError as exc:
+        print(f"upstream {remote_host}:{remote_port} unreachable: {exc}", flush=True)
+        client.close()
+        return
+    threading.Thread(target=pipe, args=(client, upstream), daemon=True).start()
+    threading.Thread(target=pipe, args=(upstream, client), daemon=True).start()
+
+
+def main():
+    if len(sys.argv) != 4:
+        sys.exit(f"usage: {sys.argv[0]} <local_port> <remote_host> <remote_port>")
+
+    local_port = int(sys.argv[1])
+    remote_host = sys.argv[2]
+    remote_port = int(sys.argv[3])
+
+    listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    # 0.0.0.0 so the Docker Desktop VM can reach it via host.docker.internal;
+    # a 127.0.0.1 bind is not reachable from containers.
+    listener.bind(("0.0.0.0", local_port))
+    listener.listen(128)
+    print(
+        f"forwarding 0.0.0.0:{local_port} -> {remote_host}:{remote_port}",
+        flush=True,
+    )
+
+    while True:
+        conn, _ = listener.accept()
+        threading.Thread(
+            target=handle, args=(conn, remote_host, remote_port), daemon=True
+        ).start()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Problem

Every `grafana` tool in the Docker MCP Gateway fails:

```
list datasources: Get "http://192.168.0.128:30080/api/datasources":
  dial tcp 192.168.0.128:30080: connect: connection refused
```

## Root cause

**Docker Desktop containers on this Mac cannot reach the LAN at all** — this is not grafana-specific. Tailscale and WireGuard hold `default` routes on utun interfaces, and container egress does not follow them.

Measured from inside a plain `alpine` container:

| From | To | Result |
|---|---|---|
| container | `ping 192.168.0.128` | **100% packet loss** |
| container | `curl 192.168.0.128:30080` | fails |
| container | `ping host.docker.internal` | works |
| host | `curl 192.168.0.128:30080` | `200` in 35ms |

The container sits on `172.17.0.0/16` with `default via 172.17.0.1` and has no path to the LAN.

## Fix

Containers *can* reach `host.docker.internal`, so the host relays. A launchd agent listens on host port 30080 and forwards to the Pi's 30080; `grafana.url` becomes `http://host.docker.internal:30080` — the same pattern CLAUDE.md already documents for host-side services like n8n.

Port 30080 mirrors the Pi's port on purpose so both sides of the relay read identically in config and logs.

Stdlib-only Python, deliberately: the agent starts under launchd before any venv exists, and a dependency would make it fail to start on a fresh machine.

## Verified

Before: `connection refused`. After:

```json
{"datasources":[
  {"uid":"alertmanager","name":"Alertmanager","type":"alertmanager"},
  {"uid":"P8E80F9AEF21F6940","name":"Loki","type":"loki"},
  {"uid":"prometheus","name":"Prometheus","type":"prometheus","isDefault":true}
],"total":3}
```

## Install

```bash
cp configs/lan-forwarder/com.homelab.lan-forwarder.plist ~/Library/LaunchAgents/
launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.homelab.lan-forwarder.plist
docker mcp profile config default --set grafana.url=http://host.docker.internal:30080
launchctl kickstart -k gui/$(id -u)/com.homelab.docker-mcp-gateway
```

## Note

If Tailscale/WireGuard routing is ever fixed so containers reach the LAN directly, this agent and the `host.docker.internal` indirection can both be dropped — point `grafana.url` back at the Pi's LAN address. The plist records this.

Refs: no-ticket

🤖 Generated with [Claude Code](https://claude.com/claude-code)