### PR TITLE
feat(finance-audit): serve the credit-card reconciliation dashboard

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -80,6 +80,18 @@ locals {
     },
 
     {
+      # finance-audit — 每月信用卡對帳／回饋稽核儀表板（靜態站，唯讀掛載 artifacts）。
+      # enable_auth 必須是 true：頁面上是敏感的個人財務資料，而這個站沒有自己的
+      # 登入機制，Zero Trust 是唯一那道門。
+      "finance-audit" = {
+        hostname    = "finance"
+        service_url = module.finance-audit.tunnel_service_url
+        enable_auth = true
+        type        = "docker"
+      }
+    },
+
+    {
       "personal-calibre-internal" = {
         hostname    = "personal-calibre-internal"
         service_url = module.personal-calibre.tunnel_service_url

--- a/main.tf
+++ b/main.tf
@@ -226,6 +226,16 @@ module "rss-manager" {
   vault_registry_path = var.vault_registry_path
 }
 
+module "finance-audit" {
+  source = "./modules/finance-audit"
+
+  project_name   = var.project_name
+  environment    = var.environment
+  image          = var.finance_audit_image
+  external_port  = 8085
+  artifacts_path = var.finance_artifacts_path
+}
+
 module "n8n" {
   source = "./modules/n8n"
 

--- a/modules/finance-audit/main.tf
+++ b/modules/finance-audit/main.tf
@@ -1,0 +1,69 @@
+# finance-audit — 每月信用卡對帳／回饋稽核的靜態儀表板（Nuxt SSG → nginx）。
+#
+# image 裡沒有任何財務資料：五份 artifacts JSON 一律從下面這個唯讀 bind mount 讀。
+# 沒掛載 → 畫面上五個「讀取失敗」，不是「0 筆」；容器仍然 healthy。
+#
+# image 由 rainforest-finance/apps/finance-audit/Dockerfile 在本機 build，未推 registry。
+# docker_container 不會自己 pull，所以 apply 前 `finance-audit:local` 必須已存在於本機 daemon。
+
+locals {
+  # 容器內部監聽埠，由 image 決定（Dockerfile 的 EXPOSE 8080）。
+  # 必須是非特權 port —— runtime 以 nginx 使用者（非 root）執行。
+  internal_port = 8080
+}
+
+resource "docker_container" "finance_audit" {
+  image   = var.image
+  name    = "${var.project_name}-finance-audit"
+  restart = "always"
+
+  memory = parseint(regex("([0-9]+)", var.memory_limit)[0], 10) * (
+    can(regex("Gi", var.memory_limit)) ? 1024 * 1024 * 1024 :
+    can(regex("Mi", var.memory_limit)) ? 1024 * 1024 : 1
+  )
+  memory_swap = -1
+
+  # 刻意只綁 loopback，不用其他服務慣用的 0.0.0.0：這個站供應敏感的個人財務資料，
+  # 且沒有自己的登入機制，唯一入口必須是過 Cloudflare Access 的隧道。
+  # 綁 0.0.0.0 會讓同網段任何裝置用 http://<LAN-IP>:8085 免認證讀到全部內容。
+  #
+  # 隧道不受影響：cloudflared pod 走 host.docker.internal（Docker Desktop gateway
+  # 192.168.65.254），該 gateway 會代理到 host loopback。已實測 pod → 只綁
+  # 127.0.0.1 的埠回 200，而同一個埠從區網 IP 連不上。
+  ports {
+    internal = local.internal_port
+    external = var.external_port
+    ip       = "127.0.0.1"
+  }
+
+  # 每月產出的 artifacts —— 唯讀掛載，這個站永遠只讀不寫。
+  # nginx 以 `location ^~ /artifacts/ { root /srv; }` 對外服務這個目錄。
+  volumes {
+    container_path = "/srv/artifacts"
+    host_path      = var.artifacts_path
+    read_only      = true
+  }
+
+  # /healthz 由 nginx 直接 return 200，不碰檔案系統。
+  # 刻意不驗 artifacts：忘了掛載要表現成畫面上的錯誤訊息，不是容器不健康。
+  healthcheck {
+    test         = ["CMD", "wget", "-q", "-O", "/dev/null", "http://127.0.0.1:${local.internal_port}/healthz"]
+    interval     = "30s"
+    timeout      = "3s"
+    start_period = "5s"
+    retries      = 3
+  }
+
+  labels {
+    label = "project"
+    value = var.project_name
+  }
+  labels {
+    label = "environment"
+    value = var.environment
+  }
+  labels {
+    label = "service"
+    value = "finance-audit"
+  }
+}

--- a/modules/finance-audit/outputs.tf
+++ b/modules/finance-audit/outputs.tf
@@ -1,0 +1,19 @@
+output "container_name" {
+  description = "Name of the Docker container"
+  value       = docker_container.finance_audit.name
+}
+
+output "external_port" {
+  description = "Host port the app is listening on"
+  value       = var.external_port
+}
+
+output "tunnel_service_url" {
+  description = "Internal URL for Cloudflare Tunnel routing"
+  value       = "http://host.docker.internal:${var.external_port}"
+}
+
+output "health_url" {
+  description = "Health endpoint (nginx returns 200 without touching the filesystem)"
+  value       = "http://host.docker.internal:${var.external_port}/healthz"
+}

--- a/modules/finance-audit/variables.tf
+++ b/modules/finance-audit/variables.tf
@@ -1,0 +1,39 @@
+variable "project_name" {
+  description = "Project name for resource naming"
+  type        = string
+  default     = "homelab"
+}
+
+variable "environment" {
+  description = "Environment name"
+  type        = string
+  default     = "dev"
+}
+
+variable "image" {
+  description = "Docker image reference. Built locally from rainforest-finance/apps/finance-audit and never pushed, so it must already exist in the local daemon before apply."
+  type        = string
+  default     = "finance-audit:local"
+}
+
+variable "external_port" {
+  description = "Host port to expose the app on"
+  type        = number
+  default     = 8085
+}
+
+variable "artifacts_path" {
+  description = "Host path to the rainforest-finance artifacts directory (mounted read-only at /srv/artifacts and served as /artifacts/*)"
+  type        = string
+
+  validation {
+    condition     = can(regex("^/", var.artifacts_path))
+    error_message = "artifacts_path must be an absolute host path — a relative or empty path makes Docker create a named volume instead of a bind mount, and the site would silently serve nothing."
+  }
+}
+
+variable "memory_limit" {
+  description = "Memory limit for the container (e.g. 128Mi, 256Mi). Static nginx — 128Mi is ample."
+  type        = string
+  default     = "128Mi"
+}

--- a/modules/finance-audit/versions.tf
+++ b/modules/finance-audit/versions.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_providers {
+    docker = {
+      source = "kreuzwerker/docker"
+    }
+  }
+}

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -34,6 +34,14 @@ default_memory_limit = "1Gi"
 default_storage_size = "10Gi"
 minio_storage_size   = "100Gi"  # MinIO storage size (larger default for object storage)
 
+# finance-audit (monthly credit-card reconciliation dashboard)
+# The image is built locally and never pushed:
+#   docker build -t finance-audit:local <rainforest-finance>/apps/finance-audit
+# finance_artifacts_path is REQUIRED and has no default — point it at the artifacts/
+# directory monthly.sh writes. Mounted read-only; the container never writes to it.
+finance_audit_image    = "finance-audit:local"
+finance_artifacts_path = "/absolute/path/to/rainforest-finance/artifacts"
+
 # Zero Trust Access Control (requires enabling Access in Cloudflare dashboard)
 # Option A: Domain-specific (recommended for security)
 allowed_email_domains = ["yourdomain.com"]  # Only allow emails from your domain

--- a/variables.tf
+++ b/variables.tf
@@ -205,6 +205,19 @@ variable "vault_registry_path" {
   default     = "/Users/rainforest/Library/Mobile Documents/iCloud~md~obsidian/Documents/rainforest-obsidian/_system"
 }
 
+variable "finance_audit_image" {
+  description = "Docker image for finance-audit. Built locally (docker build -t finance-audit:local apps/finance-audit) and never pushed — it must exist in the local daemon before apply."
+  type        = string
+  default     = "finance-audit:local"
+}
+
+# Deliberately no default: the real path is personal and stays out of version control.
+# Set it in terraform.tfvars (see terraform.tfvars.example for the shape).
+variable "finance_artifacts_path" {
+  description = "Host path to the rainforest-finance artifacts directory (mounted read-only at /srv/artifacts)"
+  type        = string
+}
+
 # grafana_mcp_version / grafana_mcp_api_key removed with the standalone grafana-mcp
 # module. Grafana MCP is now part of the Docker MCP Gateway: its image is pinned by the
 # Docker catalog digest, and its Viewer token lives in Docker Desktop's Keychain


### PR DESCRIPTION
Adds a `finance-audit` module that serves the monthly credit-card reconciliation dashboard at `finance.rainforest.tools` — a static Nuxt SSG site behind nginx, reading artifacts produced by the rainforest-finance pipeline.

## Design notes

**The image carries no data.** The five artifact JSONs come from a read-only bind mount, so refreshing the numbers is a file write rather than a rebuild. `FINANCE_AUDIT_EMBED_ARTIFACTS=0` in the Dockerfile keeps `nitro.publicAssets` from baking them in.

**A missing mount must not look like a clean month.** With nothing mounted the pages render "read failed", not "0 records", and the healthcheck (`/healthz`, served by nginx without touching the filesystem) still passes. Container health and data availability are deliberately separate signals.

**The port binds to `127.0.0.1`, unlike the other service modules.** The site serves sensitive personal data and has no login of its own, so Access is the only control — binding to `0.0.0.0` let anything on the LAN read it over `http://<LAN-IP>:8085`. The tunnel is unaffected: cloudflared reaches the host through the Docker Desktop gateway, which proxies to host loopback.

**`finance_artifacts_path` has no default** and is validated as absolute, so a misconfigured apply fails loudly instead of silently creating a named volume and serving an empty site.

## Verification

Applied and checked against the running deployment:

| Check | Result |
|---|---|
| Container | `homelab-finance-audit` healthy, `127.0.0.1:8085->8080` |
| Routes | `/` `/reconcile` `/rewards` `/fixes` `/expiry` `/healthz` all 200 |
| Artifacts mount | `/artifacts/meta.json` → 200, `schema_version: 5`, 5 months covered |
| Zero Trust | `https://finance.rainforest.tools` → 302 to `cloudflareaccess.com` |
| LAN bypass | `http://<LAN-IP>:8085/artifacts/meta.json` → connection refused |
| Tunnel after loopback change | verified from a k8s pod via `host.docker.internal` → 200 |
| `terraform validate` | Success |
| `terraform fmt` | clean on all files in this PR |

The loopback binding was tested empirically before being applied — a throwaway container bound to `127.0.0.1` was confirmed reachable from a pod through the Docker Desktop gateway and unreachable from the LAN.

## Notes

- The image is built locally and never pushed, so `finance-audit:local` must exist in the local daemon before apply; `docker_container` will not pull it.
- Unrelated working-tree changes (`modules/comfyui/server` submodule pointer) are deliberately not included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)