### PR TITLE
feat(telemetry): ship company-laptop dev metrics and events to the homelab

### DIFF
--- a/configs/dev-telemetry/README.md
+++ b/configs/dev-telemetry/README.md
@@ -1,0 +1,142 @@
+# dev-telemetry — company laptop → homelab
+
+Ships host metrics and dev-activity events from the company MacBook Air
+(`angibles-macbook-air`) to Prometheus and Loki on the Raspberry Pi, over
+Tailscale.
+
+Built to answer one question: **are concurrent `pre-push` hooks across git
+worktrees fighting each other for CPU, and is Vitest's default worker pool the
+reason?**
+
+Not managed by Terraform. Terraform in this repo owns the Docker Desktop k8s
+cluster and Docker containers on the Mac Mini; a company laptop is outside that
+blast radius and a `terraform destroy` must never be able to reach it. This
+follows the `configs/grafana-tunnel/` pattern instead: version-controlled files
+plus a documented install.
+
+## What runs where
+
+| Component | Where | How |
+|---|---|---|
+| `node_exporter` | laptop, native | launchd, `:9100`, textfile collector enabled |
+| `alloy` | laptop, native | launchd, `:12345`, pushes to the Pi |
+| `ps-sampler` | laptop | launchd, every 30s → `.prom` textfile |
+| `git-hook-wrapper` | laptop | via `core.hooksPath`, per repo |
+| Prometheus / Loki / Grafana | Pi | already deployed (`monitoring` ns) |
+
+Everything on the laptop is a **native process, not a container**. Docker
+Desktop on macOS runs containers inside a Linux VM, so a containerised
+collector reports the VM's CPU rather than the Mac's — useless when the whole
+point is real core contention.
+
+## Install
+
+```bash
+./install.sh              # install/upgrade + start
+./install.sh --verify     # status only
+```
+
+Then instrument a repo (this is the only thing that touches a repository):
+
+```bash
+./instrument-repo.sh /path/to/angible-monorepo
+./instrument-repo.sh /path/to/angible-monorepo -u    # undo
+```
+
+**Nothing is committed to the instrumented repo.** The only change is
+`git config --local core.hooksPath`, which lives in `.git/config` — untracked.
+The wrapper scripts live in `~/.config/dev-telemetry/`. `git status` stays
+clean. `instrument-repo.sh` prints a confirmation of this at the end.
+
+`core.hooksPath` is stored in the repository's *common* config, so one run
+covers every linked worktree. That sharing is also why the hooks contend.
+
+## Data model
+
+Two backends, split by the nature of the data:
+
+- **Prometheus** — continuous numeric state. Low-cardinality labels only.
+- **Loki** — discrete events. Only `event` and `status` become labels;
+  everything else (branch, worktree, durations) rides in the log body, where
+  Loki does not index it and it therefore costs nothing.
+
+A branch name promoted to a label — in either backend — creates a new
+series/stream per feature branch and is an unbounded-cardinality bomb.
+
+Event line:
+
+```json
+{"ts":"2026-08-14T09:58:54Z","event":"git-hook","status":"ok","hook":"pre-push",
+ "dur_ms":74210,"exit":0,"worktree":"feat-x","branch":"feat/central-pos-sync"}
+```
+
+`status` is `ok` / `fail` / `interrupted`. Numbers are emitted unquoted so
+LogQL `unwrap` reads them directly.
+
+Metrics from `ps-sampler`:
+
+| Metric | Meaning |
+|---|---|
+| `dev_vitest_workers` | live vitest processes — **the number you will end up capping** |
+| `dev_hooks_running` | git hooks in flight — overlap is the contention |
+| `dev_proc_cpu_percent{name}` | top-10 by CPU, plus a fixed allowlist |
+| `dev_proc_rss_bytes{name}` | same set, resident memory |
+
+## Verify
+
+```bash
+curl -s 127.0.0.1:9100/metrics | grep -c '^node_'   # 1. collector up
+curl -s 127.0.0.1:12345/-/ready                     # 2. shipper up
+# 3. transport — on any machine that can reach the Pi:
+curl -sG http://raspberrypi-5:30090/api/v1/query --data-urlencode \
+     'query=up{host="angible-macbook-air"}'
+# 4. log pipeline
+~/.config/dev-telemetry/bin/devlog test ok note hello
+# 5. real push — run one, then check the event landed
+```
+
+Step 3 is the watershed: it proves Tailscale, the ACL and remote_write at once.
+Failures at 1–2 are collection; failures at 3 are transport.
+
+## Gotchas
+
+**`launchctl kickstart -k` does not re-read the plist.** It restarts from
+launchd's in-memory job definition, so an edited plist appears to apply while
+the old arguments keep running. Always:
+
+```bash
+launchctl bootout gui/$(id -u)/com.homelab.dev-alloy
+launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.homelab.dev-alloy.plist
+```
+
+**Prometheus 3.x moved retention out of the CLI flags.** On the Pi,
+`/api/v1/status/flags` still reports a vestigial `1w` and the operator's
+StatefulSet has no `--storage.tsdb.retention.*` argument. The real value is at
+`/api/v1/status/config` under `storage.tsdb.retention`. Checking `flags` gives
+the wrong answer.
+
+**`helm --dry-run=client` silently ignores `--reuse-values`.** It does not
+contact the cluster, so there are no existing values to reuse and the render
+comes out with empty sections that look like a config bug. Use
+`--dry-run=server`.
+
+**Loki's `table_manager` retention does not delete chunks** under
+boltdb-shipper + filesystem — it only drops index tables. Only the compactor
+with `retention_enabled: true` reclaims disk. A config showing
+`retention_deletes_enabled: true` can still be growing forever.
+
+**The Pi must be on the tailnet.** If it drops off, Alloy buffers to its
+remote_write WAL and replays on reconnect, so a few hours offline costs
+nothing. Days will drop data — and Loki additionally rejects pushes older than
+`reject_old_samples_max_age` (currently 168h).
+
+## Uninstall
+
+```bash
+for l in dev-node-exporter dev-alloy dev-ps-sampler; do
+  launchctl bootout "gui/$(id -u)/com.homelab.$l" 2>/dev/null
+  rm -f ~/Library/LaunchAgents/com.homelab.$l.plist
+done
+rm -rf ~/.config/dev-telemetry ~/.local/state/dev-telemetry
+# plus ./instrument-repo.sh <repo> -u for each instrumented repo
+```

--- a/configs/dev-telemetry/README.md
+++ b/configs/dev-telemetry/README.md
@@ -125,10 +125,22 @@ boltdb-shipper + filesystem — it only drops index tables. Only the compactor
 with `retention_enabled: true` reclaims disk. A config showing
 `retention_deletes_enabled: true` can still be growing forever.
 
-**The Pi must be on the tailnet.** If it drops off, Alloy buffers to its
-remote_write WAL and replays on reconnect, so a few hours offline costs
-nothing. Days will drop data — and Loki additionally rejects pushes older than
-`reject_old_samples_max_age` (currently 168h).
+**`loki.write` has no disk WAL by default; `prometheus.remote_write` does.**
+Measured on the Pi's first reconnect: 32,623 metric samples replayed intact,
+while a log entry from ten minutes earlier was already gone — `final error
+sending batch, no retries left, dropping data`. The weaker default covers the
+more valuable data, since a dropped metric sample is a gap the next scrape
+refills but a dropped event is a hook run that happened once. `config.alloy`
+therefore enables the `wal` block on `loki.write` explicitly.
+
+**The Pi must be on the tailnet.** With both WALs enabled, hours offline cost
+nothing. Days still lose data, and Loki rejects pushes older than
+`reject_old_samples_max_age` (currently 168h) regardless of buffering.
+
+**`tailscaled` was installed but `systemctl disabled` on the Pi**, and its
+backend state was `Logged out.` — two independent faults producing one symptom.
+Starting the unit without enabling it survives until the next reboot and then
+fails identically, which is what makes it feel unfixable.
 
 ## Uninstall
 

--- a/configs/dev-telemetry/alloy/config.alloy
+++ b/configs/dev-telemetry/alloy/config.alloy
@@ -1,0 +1,105 @@
+// Grafana Alloy — company MacBook Air (angibles-macbook-air)
+//
+// Ships host metrics to Prometheus and dev-activity events to Loki, both on
+// the Raspberry Pi, reached over Tailscale. Runs as a native launchd process,
+// not a container: Docker Desktop on macOS runs containers inside a Linux VM,
+// so a containerised collector reports the VM's CPU rather than the Mac's —
+// and measuring real core contention is the entire point here.
+//
+// Endpoints come from the launchd plist's EnvironmentVariables. There are no
+// secrets: the tailnet is the authentication boundary.
+
+// ─── Metrics: scrape the native node_exporter, push to the Pi ───────────────
+
+prometheus.scrape "host" {
+  targets = [{
+    __address__ = "127.0.0.1:9100",
+    job         = "macbook-node",
+  }]
+  forward_to = [prometheus.remote_write.rpi.receiver]
+
+  // 15s rather than the Mac Mini's 30s. A pre-push hook runs 30-120s, so 30s
+  // sampling yields 1-4 points and the CPU plateau is not resolvable. At 15s a
+  // 60s hook gets four samples. Costs ~5 MB/day on the Pi, which is ~2% of its
+  // existing ingest.
+  scrape_interval = "15s"
+}
+
+prometheus.remote_write "rpi" {
+  // WITHOUT THIS the laptop's node_exporter series collide with the Mac Mini's
+  // — same metric names, same instance label — and the two machines silently
+  // overwrite each other. This is the single most confusing way a second Alloy
+  // can fail, because the graphs look plausible and are wrong.
+  external_labels = {
+    host = "angible-macbook-air",
+  }
+
+  endpoint {
+    url = sys.env("PROMETHEUS_REMOTE_WRITE_URL")
+
+    queue_config {
+      max_samples_per_send = 1000
+      batch_send_deadline  = "5s"
+    }
+  }
+}
+
+// ─── Logs: tail the event spool, push to the Pi ─────────────────────────────
+
+local.file_match "dev_events" {
+  path_targets = [{
+    __path__ = sys.env("DEV_EVENTS_SPOOL"),
+    job      = "dev-events",
+  }]
+}
+
+loki.source.file "dev_events" {
+  targets    = local.file_match.dev_events.targets
+  forward_to = [loki.process.dev_events.receiver]
+}
+
+loki.process "dev_events" {
+  stage.json {
+    expressions = {
+      event  = "event",
+      status = "status",
+      ts     = "ts",
+    }
+  }
+
+  // Use the emitter's timestamp, not ingest time. Alloy buffers to disk while
+  // the Pi is unreachable and replays later; without this every replayed event
+  // would land bunched at the moment the tunnel came back.
+  stage.timestamp {
+    source = "ts"
+    format = "RFC3339"
+  }
+
+  // Only these two become labels. Together with job and host that is a bounded
+  // label set. Everything high-cardinality — branch, worktree, duration —
+  // stays in the log body, where Loki does not index it and it therefore costs
+  // nothing. A branch name promoted to a label would create a new stream per
+  // feature branch and blow up the index.
+  //
+  // Note the `values` map: Alloy's stage.labels takes one, unlike Promtail's
+  // YAML where the label names are keys directly under the stage. Writing it
+  // the Promtail way fails the initial load with "unrecognized attribute name".
+  stage.labels {
+    values = {
+      event  = "",
+      status = "",
+    }
+  }
+
+  forward_to = [loki.write.rpi.receiver]
+}
+
+loki.write "rpi" {
+  external_labels = {
+    host = "angible-macbook-air",
+  }
+
+  endpoint {
+    url = sys.env("LOKI_PUSH_URL")
+  }
+}

--- a/configs/dev-telemetry/alloy/config.alloy
+++ b/configs/dev-telemetry/alloy/config.alloy
@@ -102,4 +102,20 @@ loki.write "rpi" {
   endpoint {
     url = sys.env("LOKI_PUSH_URL")
   }
+
+  // NOT the default, and the default is the wrong trade here.
+  //
+  // prometheus.remote_write buffers to disk out of the box; loki.write keeps
+  // its queue in memory and drops entries once retries are exhausted. Measured
+  // during the Pi's first reconnect: 32,623 metric samples replayed intact
+  // while a log entry from ten minutes earlier was already gone
+  // ("final error sending batch, no retries left, dropping data").
+  //
+  // The weaker guarantee happens to cover the more valuable data. A dropped
+  // metric sample is a gap in a curve that the next scrape refills; a dropped
+  // event is a pre-push run that happened once and is now unrecoverable.
+  wal {
+    enabled         = true
+    max_segment_age = "4h"
+  }
 }

--- a/configs/dev-telemetry/bin/build-guard
+++ b/configs/dev-telemetry/bin/build-guard
@@ -1,0 +1,118 @@
+#!/bin/sh
+# build-guard [-n SLOTS] [-t WAIT_SECONDS] -- <command...>
+#
+# Serialises expensive builds so concurrent ones cannot exhaust memory, and
+# records how long each one waited.
+#
+# Why a wait-and-run guard rather than a memory cap: the failure being
+# prevented is memory exhaustion, measured at 22.5 GB of swap with 80 MB of
+# RAM free while several next-build processes ran at once. Capping node's heap
+# instead (NODE_OPTIONS=--max-old-space-size) applies everywhere but converts a
+# slow build into a crashed one, since a large Next.js build legitimately wants
+# several GB. Waiting costs time and nothing else.
+#
+# Locks are directories: mkdir is atomic on every filesystem, and macOS ships no
+# flock(1). A slot whose owner died is reclaimed, so a killed build cannot
+# wedge the queue permanently.
+#
+# The guard NEVER refuses to run. If the wait expires it proceeds anyway and
+# says so in the telemetry — a build tool that sometimes silently declines to
+# build would be worse than the contention it prevents.
+
+set -u
+
+SLOTS=1
+WAIT_MAX=900
+STATE_DIR="${DEV_TELEMETRY_STATE:-$HOME/.local/state/dev-telemetry}"
+LOCK_ROOT="$STATE_DIR/build-slots"
+DEVLOG="${DEV_TELEMETRY_BIN:-$HOME/.config/dev-telemetry/bin}/devlog"
+
+while [ $# -gt 0 ]; do
+    case $1 in
+        -n) SLOTS=$2; shift 2 ;;
+        -t) WAIT_MAX=$2; shift 2 ;;
+        --) shift; break ;;
+        *)  break ;;
+    esac
+done
+
+[ $# -gt 0 ] || { echo "usage: build-guard [-n SLOTS] [-t SECONDS] -- <command...>" >&2; exit 2; }
+
+mkdir -p "$LOCK_ROOT" 2>/dev/null
+
+# Drop slots whose owning process is gone. Without this a SIGKILLed build leaks
+# its slot and every later build waits out the full timeout for nothing.
+reap_stale() {
+    for slot in "$LOCK_ROOT"/*; do
+        [ -d "$slot" ] || continue
+        pid=$(cat "$slot/pid" 2>/dev/null) || continue
+        [ -n "$pid" ] || continue
+        kill -0 "$pid" 2>/dev/null || rm -rf "$slot" 2>/dev/null
+    done
+}
+
+HELD=""
+acquire() {
+    i=0
+    while [ "$i" -lt "$SLOTS" ]; do
+        if mkdir "$LOCK_ROOT/slot$i" 2>/dev/null; then
+            echo $$ >"$LOCK_ROOT/slot$i/pid" 2>/dev/null
+            HELD="$LOCK_ROOT/slot$i"
+            return 0
+        fi
+        i=$((i + 1))
+    done
+    return 1
+}
+
+release() { [ -n "$HELD" ] && rm -rf "$HELD" 2>/dev/null; }
+trap 'release' EXIT INT TERM
+
+START=$(date +%s)
+WAITED=0
+TIMED_OUT=0
+
+reap_stale
+until acquire; do
+    if [ $(( $(date +%s) - START )) -ge "$WAIT_MAX" ]; then
+        TIMED_OUT=1
+        break
+    fi
+    # 1s, not 5s: the poll interval is also the resolution of wait_ms, so a
+    # coarse one both wastes idle time after a slot frees and overstates the
+    # contention it is measuring. A waiting process doing one mkdir per second
+    # costs nothing next to the build it is queued behind.
+    sleep 1
+    reap_stale
+done
+
+# Measure AFTER the loop, never inside it. Computing the wait at the top of each
+# iteration records the time before that iteration's sleep, so a build that
+# acquires on the second attempt reports a wait of zero — and wait_ms is the
+# entire reason this guard emits telemetry at all.
+WAITED=$(( $(date +%s) - START ))
+
+RUN_START=$(date +%s)
+"$@"
+EXIT_CODE=$?
+DUR=$(( ($(date +%s) - RUN_START) * 1000 ))
+
+# Free the slot before doing bookkeeping. The trap would release it eventually,
+# but that runs after the telemetry write, so the next queued build would sit
+# waiting on a slot whose work has already finished.
+release
+HELD=""
+
+{
+    [ -x "$DEVLOG" ] && "$DEVLOG" build \
+        "$([ "$EXIT_CODE" -eq 0 ] && echo ok || echo fail)" \
+        cmd "$(basename "$1")" \
+        dur_ms "$DUR" \
+        wait_ms "$((WAITED * 1000))" \
+        queued "$([ "$WAITED" -gt 0 ] && echo 1 || echo 0)" \
+        timed_out "$TIMED_OUT" \
+        exit "$EXIT_CODE" \
+        worktree "$(basename "$(git rev-parse --show-toplevel 2>/dev/null || echo unknown)")"
+} >/dev/null 2>&1
+
+exit $EXIT_CODE

--- a/configs/dev-telemetry/bin/devlog
+++ b/configs/dev-telemetry/bin/devlog
@@ -1,0 +1,72 @@
+#!/bin/sh
+# devlog EVENT STATUS [key value]...
+#
+# Appends exactly one JSON line to the event spool. Every other emitter in this
+# directory goes through here.
+#
+# Two properties this file exists to guarantee:
+#
+#   1. ATOMIC APPEND. Several git worktrees write here at the same moment —
+#      that concurrency is the thing being measured, so the instrument must not
+#      corrupt itself under it. A single printf to an O_APPEND fd is atomic for
+#      short writes; a read-modify-write or multiple printfs would interleave.
+#      Keep it one printf, keep lines well under 4 KiB.
+#
+#   2. NEVER FAIL LOUDLY. This runs inside git hooks. A full disk or a missing
+#      directory must not print anything or return non-zero, or it changes the
+#      behaviour of a real push.
+
+set -u
+
+STATE_DIR="${DEV_TELEMETRY_STATE:-$HOME/.local/state/dev-telemetry}"
+SPOOL="$STATE_DIR/events.jsonl"
+MAX_BYTES=$((32 * 1024 * 1024))
+
+# Escape a value for use inside a JSON string: backslash, quote, then strip
+# control characters (a raw newline would split one event into two lines).
+json_escape() {
+    printf '%s' "$1" \
+        | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g' \
+        | tr -d '\000-\037'
+}
+
+emit() {
+    [ $# -ge 2 ] || return 0
+    _event=$1
+    _status=$2
+    shift 2
+
+    _line="{\"ts\":\"$(date -u '+%Y-%m-%dT%H:%M:%SZ')\""
+    _line="$_line,\"event\":\"$(json_escape "$_event")\""
+    _line="$_line,\"status\":\"$(json_escape "$_status")\""
+
+    while [ $# -ge 2 ]; do
+        _k=$(json_escape "$1")
+        _v=$2
+        # Bare integers stay unquoted so LogQL `unwrap` can read them directly.
+        case $_v in
+            ''|*[!0-9-]*) _line="$_line,\"$_k\":\"$(json_escape "$_v")\"" ;;
+            *)            _line="$_line,\"$_k\":$_v" ;;
+        esac
+        shift 2
+    done
+
+    printf '%s}\n' "$_line" >>"$SPOOL"
+}
+
+# Cheap size guard. Alloy tracks its read offset by inode, so rotating by
+# rename would silently lose the tail; truncating in place keeps the inode and
+# Alloy simply resumes. Losing old spool lines is fine — they already shipped.
+rotate_if_huge() {
+    _size=$(wc -c <"$SPOOL" 2>/dev/null || echo 0)
+    [ "$_size" -gt "$MAX_BYTES" ] 2>/dev/null && : >"$SPOOL"
+    return 0
+}
+
+{
+    mkdir -p "$STATE_DIR" 2>/dev/null
+    rotate_if_huge
+    emit "$@"
+} >/dev/null 2>&1
+
+exit 0

--- a/configs/dev-telemetry/bin/git-hook-wrapper
+++ b/configs/dev-telemetry/bin/git-hook-wrapper
@@ -37,7 +37,13 @@ EXIT_CODE=1
 
 REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo "")
 WORKTREE=$(basename "${REPO_ROOT:-unknown}")
-BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)
+
+# Assign, then fall back on failure — do NOT write `$(cmd || echo unknown)`.
+# On an unborn HEAD, `git rev-parse --abbrev-ref HEAD` prints "HEAD" on stdout
+# *and* exits non-zero, so the `||` branch appends to the captured output and
+# yields the nonsense value "HEADunknown".
+BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null) || BRANCH=""
+[ -n "$BRANCH" ] && [ "$BRANCH" != "HEAD" ] || BRANCH=unknown
 
 emit() {
     {

--- a/configs/dev-telemetry/bin/git-hook-wrapper
+++ b/configs/dev-telemetry/bin/git-hook-wrapper
@@ -1,0 +1,103 @@
+#!/bin/sh
+# Transparent instrumentation wrapper for git hooks.
+#
+# Installed by pointing a repo's core.hooksPath at the directory holding the
+# symlinks that invoke this script. The original hooksPath is saved first, in
+# telemetry.originalHooksPath, and this wrapper delegates to it.
+#
+# THE CONTRACT — this sits in the path of every real `git push`:
+#
+#   * The real hook's exit code is passed through byte-for-byte.
+#   * stdin is passed through untouched. pre-push receives its refs on stdin;
+#     consuming even one line here would silently change what gets tested.
+#   * Telemetry never writes to stdout/stderr — that output would land in the
+#     middle of git's own, and any error here is swallowed rather than raised.
+#   * If anything about the telemetry is broken, the hook still runs.
+#
+# Nothing in this file is committed to the instrumented repository: the wrapper
+# lives outside it and core.hooksPath is local git config, which is stored in
+# .git/config and is not version controlled.
+
+set -u
+
+HOOK_NAME=$(basename "$0")
+STATE_DIR="${DEV_TELEMETRY_STATE:-$HOME/.local/state/dev-telemetry}"
+RUNNING_DIR="$STATE_DIR/running"
+DEVLOG="${DEV_TELEMETRY_BIN:-$HOME/.config/dev-telemetry/bin}/devlog"
+MARKER="$RUNNING_DIR/$$.$HOOK_NAME"
+
+START_S=$(date +%s)
+# Assume the worst: if we are killed before the hook returns, the event still
+# records what happened. Emitting one self-contained line at the end — rather
+# than pairing a start and an end line — is what makes interrupted runs
+# countable instead of invisible, and they cluster exactly when the machine is
+# most contended.
+STATUS=interrupted
+EXIT_CODE=1
+
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo "")
+WORKTREE=$(basename "${REPO_ROOT:-unknown}")
+BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)
+
+emit() {
+    {
+        _dur=$(( ($(date +%s) - START_S) * 1000 ))
+        rm -f "$MARKER" 2>/dev/null
+        [ -x "$DEVLOG" ] && "$DEVLOG" git-hook "$STATUS" \
+            hook "$HOOK_NAME" \
+            dur_ms "$_dur" \
+            exit "$EXIT_CODE" \
+            worktree "$WORKTREE" \
+            branch "$BRANCH"
+    } >/dev/null 2>&1
+    return 0
+}
+trap emit EXIT INT TERM
+
+# A marker file per in-flight hook. ps-sampler counts these to produce
+# dev_hooks_running, which is what makes "two worktrees collided" a number on a
+# graph rather than something to be inferred from timestamps.
+{ mkdir -p "$RUNNING_DIR" && : >"$MARKER"; } >/dev/null 2>&1
+
+# Resolve the hook this wrapper is standing in front of.
+ORIG_PATH=$(git config --get telemetry.originalHooksPath 2>/dev/null || echo "")
+[ -n "$ORIG_PATH" ] || ORIG_PATH=".git/hooks"
+case $ORIG_PATH in
+    /*) REAL_HOOK="$ORIG_PATH/$HOOK_NAME" ;;
+    *)  REAL_HOOK="${REPO_ROOT:-.}/$ORIG_PATH/$HOOK_NAME" ;;
+esac
+
+# husky v9 keeps the user-facing hooks in .husky/ and points core.hooksPath at
+# .husky/_/, so fall back to the parent when the shim is absent.
+if [ ! -x "$REAL_HOOK" ] && [ -n "$REPO_ROOT" ] && [ -x "$REPO_ROOT/.husky/$HOOK_NAME" ]; then
+    REAL_HOOK="$REPO_ROOT/.husky/$HOOK_NAME"
+fi
+
+if [ -x "$REAL_HOOK" ]; then
+    "$REAL_HOOK" "$@"
+    EXIT_CODE=$?
+else
+    # No hook to run is a success, not a failure — the same thing git would do.
+    EXIT_CODE=0
+fi
+
+# Classify from the exit code rather than from the trap. A POSIX shell defers
+# trap handlers until the running command returns, so a signal arriving while
+# the real hook is mid-flight cannot flip a variable in time. What does survive
+# is the exit code: a process killed by a signal exits 128+signum, so 130 is
+# Ctrl-C and 143 is SIGTERM. Counting those separately matters because
+# interrupted runs cluster exactly when the machine is most contended, and
+# folding them into "fail" would hide that.
+#
+# Not detectable here: SIGKILL of this wrapper, which runs no trap at all. Such
+# a run leaves its marker file behind and ps-sampler prunes it, so the gauge
+# stays honest even though no event is emitted.
+if [ "$EXIT_CODE" -eq 0 ]; then
+    STATUS=ok
+elif [ "$EXIT_CODE" -gt 128 ]; then
+    STATUS=interrupted
+else
+    STATUS=fail
+fi
+
+exit $EXIT_CODE

--- a/configs/dev-telemetry/bin/ps-sampler
+++ b/configs/dev-telemetry/bin/ps-sampler
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""Sample per-process CPU/RSS into a node_exporter textfile.
+
+Runs from launchd every 30s. Exists because process-exporter is Linux-only —
+it parses /proc, which Darwin does not have — so there is no drop-in answer to
+"which process ate my CPU" on macOS.
+
+Also derives the two numbers the whole exercise is aimed at:
+
+    dev_vitest_workers   how many vitest processes are alive right now
+    dev_hooks_running    how many git hooks are mid-flight
+
+dev_vitest_workers is why there is no separate vitest emitter. Getting vitest
+to report its own pool size means either a custom reporter registered in
+vitest.config.ts (a committed change to the company repo) or a --reporter flag
+on an invocation that a git hook makes internally, where nothing can be
+injected. Counting the processes from outside needs neither.
+
+Cardinality is bounded on purpose: only the top N by CPU plus a fixed
+allowlist ever become series names. An unbounded process-name label on a dev
+machine grows forever — every one-off binary you run becomes a permanent
+series in the Pi's TSDB.
+"""
+
+import os
+import re
+import subprocess
+import sys
+import time
+
+# Kept byte-identical to running_vitest_workers() in
+# service-dashboard-frontend/.husky/pre-push. See count_vitest().
+VITEST_WORKER_RE = re.compile(
+    r"^[^ ]*/node .*--require [^ ]*vitest/suppress-warnings"
+)
+
+STATE_DIR = os.environ.get(
+    "DEV_TELEMETRY_STATE", os.path.expanduser("~/.local/state/dev-telemetry")
+)
+TEXTFILE_DIR = os.path.join(STATE_DIR, "textfile")
+RUNNING_DIR = os.path.join(STATE_DIR, "running")
+OUT = os.path.join(TEXTFILE_DIR, "dev_telemetry.prom")
+
+TOP_N = 10
+
+# Always reported even when below the top-N cut, so a panel never shows a gap
+# just because the machine was briefly quiet.
+ALWAYS = {
+    "node", "vitest", "esbuild", "tsc", "eslint", "jest",
+    "git", "Docker", "com.docker.backend", "docker",
+    "Code Helper", "rustc", "cargo", "python3", "java",
+}
+
+
+def sample_processes():
+    """Aggregate CPU% and RSS by executable basename."""
+    try:
+        raw = subprocess.run(
+            ["ps", "-Ao", "pcpu=,rss=,comm="],
+            capture_output=True, text=True, timeout=10,
+        ).stdout
+    except (subprocess.SubprocessError, OSError):
+        return {}
+
+    agg = {}
+    for line in raw.splitlines():
+        parts = line.split(None, 2)
+        if len(parts) < 3:
+            continue
+        try:
+            cpu, rss_kb = float(parts[0]), float(parts[1])
+        except ValueError:
+            continue
+        # comm is a full path; the basename is the only part that is both
+        # stable as a label and free of directory names worth not exporting.
+        name = os.path.basename(parts[2].strip())
+        cur = agg.setdefault(name, [0.0, 0.0])
+        cur[0] += cpu
+        cur[1] += rss_kb * 1024
+    return agg
+
+
+def count_vitest():
+    """Count live vitest processes (the pool parent plus its workers).
+
+    Reads full argv because vitest workers are plain `node`, indistinguishable
+    by comm alone. The argv is matched and then discarded — only the count is
+    exported, so no file paths leave the machine through this metric.
+
+    Substring-matching "vitest" across every process is not enough: an editor
+    with a test file open, a `grep vitest`, or the shell that launched this
+    sampler all carry the word in their argv and would inflate the count.
+
+    THE PATTERN BELOW IS DELIBERATELY IDENTICAL to running_vitest_workers() in
+    service-dashboard-frontend's .husky/pre-push, which is what decides whether
+    to set VITEST_MAX_FORKS=3. If this metric counted anything different, the
+    dashboard would disagree with the mechanism it is meant to explain — and a
+    number that quietly means something other than you think is worse than no
+    number. Keep the two in sync; if the hook's regex changes, change this.
+
+    It anchors on a node binary at argv[0] loading vitest's suppress-warnings
+    shim, which is the signature of a real pool worker and nothing else.
+    """
+    try:
+        raw = subprocess.run(
+            ["ps", "-Ao", "args="], capture_output=True, text=True, timeout=10
+        ).stdout
+    except (subprocess.SubprocessError, OSError):
+        return 0
+
+    return sum(1 for line in raw.splitlines() if VITEST_WORKER_RE.match(line))
+
+
+def count_running_hooks():
+    """Count in-flight git hooks, pruning markers whose process is gone.
+
+    A hook killed with SIGKILL never runs its trap, so its marker would leak
+    and inflate the count forever. Checking liveness with signal 0 keeps the
+    gauge honest.
+    """
+    try:
+        names = os.listdir(RUNNING_DIR)
+    except OSError:
+        return 0
+
+    alive = 0
+    for name in names:
+        pid_part = name.split(".", 1)[0]
+        try:
+            pid = int(pid_part)
+        except ValueError:
+            continue
+        try:
+            os.kill(pid, 0)
+            alive += 1
+        except ProcessLookupError:
+            try:
+                os.remove(os.path.join(RUNNING_DIR, name))
+            except OSError:
+                pass
+        except PermissionError:
+            alive += 1
+    return alive
+
+
+def escape(value):
+    return value.replace("\\", r"\\").replace('"', r"\"").replace("\n", "")
+
+
+def render(procs, vitest, hooks):
+    top = sorted(procs.items(), key=lambda kv: kv[1][0], reverse=True)[:TOP_N]
+    selected = dict(top)
+    for name in ALWAYS:
+        if name in procs and name not in selected:
+            selected[name] = procs[name]
+
+    out = [
+        "# HELP dev_proc_cpu_percent CPU percent by process name (summed across PIDs).",
+        "# TYPE dev_proc_cpu_percent gauge",
+    ]
+    for name, (cpu, _) in selected.items():
+        out.append(f'dev_proc_cpu_percent{{name="{escape(name)}"}} {cpu:.2f}')
+
+    out += [
+        "# HELP dev_proc_rss_bytes Resident memory by process name (summed across PIDs).",
+        "# TYPE dev_proc_rss_bytes gauge",
+    ]
+    for name, (_, rss) in selected.items():
+        out.append(f'dev_proc_rss_bytes{{name="{escape(name)}"}} {rss:.0f}')
+
+    out += [
+        "# HELP dev_vitest_workers Live vitest processes (pool parent plus workers).",
+        "# TYPE dev_vitest_workers gauge",
+        f"dev_vitest_workers {vitest}",
+        "# HELP dev_hooks_running Git hooks currently executing.",
+        "# TYPE dev_hooks_running gauge",
+        f"dev_hooks_running {hooks}",
+        "# HELP dev_sampler_last_run_timestamp_seconds Unix time of the last sampler run.",
+        "# TYPE dev_sampler_last_run_timestamp_seconds gauge",
+        f"dev_sampler_last_run_timestamp_seconds {time.time():.0f}",
+    ]
+    return "\n".join(out) + "\n"
+
+
+def main():
+    os.makedirs(TEXTFILE_DIR, exist_ok=True)
+    body = render(sample_processes(), count_vitest(), count_running_hooks())
+
+    # Write-then-rename. node_exporter's textfile collector reads on its own
+    # schedule; catching a half-written file makes it discard the whole batch
+    # and report a parse error. rename(2) within one filesystem is atomic, so
+    # the reader only ever sees a complete file.
+    tmp = OUT + ".tmp"
+    with open(tmp, "w") as fh:
+        fh.write(body)
+    os.replace(tmp, OUT)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as exc:  # noqa: BLE001 - a sampler must not wedge launchd
+        print(f"ps-sampler: {exc}", file=sys.stderr)
+        sys.exit(0)

--- a/configs/dev-telemetry/install.sh
+++ b/configs/dev-telemetry/install.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# Install the dev-telemetry collectors on a Mac.
+#
+# Idempotent: re-running upgrades the config and restarts the agents.
+# Touches nothing inside any git repository — see instrument-repo for that.
+#
+#   ./install.sh            install/upgrade and start
+#   ./install.sh --verify   report status only, change nothing
+
+set -euo pipefail
+
+SRC="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEST="$HOME/.config/dev-telemetry"
+STATE="$HOME/.local/state/dev-telemetry"
+AGENTS="$HOME/Library/LaunchAgents"
+BREW="$(brew --prefix 2>/dev/null || echo /opt/homebrew)"
+LABELS=(com.homelab.dev-node-exporter com.homelab.dev-alloy com.homelab.dev-ps-sampler)
+
+say() { printf '\033[1;34m==>\033[0m %s\n' "$*"; }
+ok()  { printf '    \033[32m✓\033[0m %s\n' "$*"; }
+bad() { printf '    \033[31m✗\033[0m %s\n' "$*"; }
+
+verify() {
+    say "launchd agents"
+    # Snapshot the list once rather than piping it into grep per label.
+    # `launchctl list | grep -q` is a false-negative trap under `set -o
+    # pipefail`: grep -q exits on the first match, launchctl takes SIGPIPE
+    # (141), and pipefail promotes that to the pipeline's status. Whether it
+    # bites depends on how early the match appears in the stream, so it fails
+    # for the first label and passes for the rest.
+    local listing
+    listing=$(launchctl list || true)
+    for l in "${LABELS[@]}"; do
+        case $listing in
+            *"$l"*) ok "$l loaded" ;;
+            *)      bad "$l NOT loaded" ;;
+        esac
+    done
+
+    say "collectors"
+    if curl -fsS --max-time 3 http://127.0.0.1:9100/metrics >/dev/null 2>&1; then
+        ok "node_exporter responding ($(curl -fsS http://127.0.0.1:9100/metrics | grep -vc '^#') series)"
+    else
+        bad "node_exporter not responding on 127.0.0.1:9100"
+    fi
+    if curl -fsS --max-time 3 http://127.0.0.1:12345/-/ready >/dev/null 2>&1; then
+        ok "alloy ready"
+    else
+        bad "alloy not ready on 127.0.0.1:12345"
+    fi
+
+    say "textfile collector"
+    if [ -f "$STATE/textfile/dev_telemetry.prom" ]; then
+        ok "$(grep -c '^dev_' "$STATE/textfile/dev_telemetry.prom") dev_* metrics written"
+        grep -E '^dev_(vitest_workers|hooks_running)' "$STATE/textfile/dev_telemetry.prom" | sed 's/^/      /'
+    else
+        bad "no textfile output yet (sampler runs every 30s)"
+    fi
+
+    say "transport to the Pi"
+    if curl -fsS --max-time 5 "http://raspberrypi-5:30090/-/healthy" >/dev/null 2>&1; then
+        ok "Pi Prometheus reachable over the tailnet"
+    else
+        bad "Pi unreachable — is raspberrypi-5 on the tailnet? (tailscale status)"
+    fi
+}
+
+if [ "${1:-}" = "--verify" ]; then verify; exit 0; fi
+
+say "Installing Homebrew dependencies"
+for pkg in node_exporter grafana-alloy; do
+    if brew list "$pkg" >/dev/null 2>&1; then
+        ok "$pkg already installed"
+    else
+        brew install "$pkg"
+    fi
+done
+
+say "Creating directories"
+mkdir -p "$DEST/bin" "$DEST/alloy" "$DEST/hooks" \
+         "$STATE/textfile" "$STATE/running" "$STATE/alloy" \
+         "$AGENTS" "$HOME/Library/Logs"
+ok "$DEST"
+ok "$STATE"
+
+say "Installing scripts and config"
+install -m 0755 "$SRC/bin/devlog"           "$DEST/bin/devlog"
+install -m 0755 "$SRC/bin/ps-sampler"       "$DEST/bin/ps-sampler"
+install -m 0755 "$SRC/bin/git-hook-wrapper" "$DEST/bin/git-hook-wrapper"
+install -m 0644 "$SRC/alloy/config.alloy"   "$DEST/alloy/config.alloy"
+ok "scripts -> $DEST/bin"
+
+# One shared hook directory that every instrumented repo points core.hooksPath
+# at. Each entry is a symlink, so the wrapper reads its own basename to learn
+# which hook it is standing in for.
+for hook in pre-push pre-commit; do
+    ln -sf "$DEST/bin/git-hook-wrapper" "$DEST/hooks/$hook"
+done
+ok "hook shims -> $DEST/hooks"
+
+say "Installing launchd agents"
+for l in "${LABELS[@]}"; do
+    sed -e "s|__HOME__|$HOME|g" -e "s|__BREW__|$BREW|g" \
+        "$SRC/launchd/$l.plist" > "$AGENTS/$l.plist"
+done
+ok "plists -> $AGENTS (with \$HOME=$HOME, brew=$BREW)"
+
+say "Restarting agents"
+# bootout + bootstrap, never kickstart: kickstart restarts from launchd's
+# in-memory job definition and silently keeps running the OLD arguments.
+#
+# bootout returns before launchd has finished tearing the job down, so an
+# immediate bootstrap loses a race and fails with the uninformative
+# "Bootstrap failed: 5: Input/output error". Wait for the label to actually
+# disappear, then retry a few times.
+for l in "${LABELS[@]}"; do
+    launchctl bootout "gui/$(id -u)/$l" 2>/dev/null || true
+
+    for _ in $(seq 20); do
+        launchctl list | grep -q "	$l\$" || break
+        sleep 0.25
+    done
+
+    for attempt in 1 2 3 4 5; do
+        if launchctl bootstrap "gui/$(id -u)" "$AGENTS/$l.plist" 2>/dev/null; then
+            ok "$l"
+            break
+        fi
+        [ "$attempt" -eq 5 ] && bad "$l failed to bootstrap after 5 attempts"
+        sleep 1
+    done
+done
+
+say "Waiting for collectors to come up"
+sleep 6
+verify

--- a/configs/dev-telemetry/install.sh
+++ b/configs/dev-telemetry/install.sh
@@ -87,6 +87,7 @@ say "Installing scripts and config"
 install -m 0755 "$SRC/bin/devlog"           "$DEST/bin/devlog"
 install -m 0755 "$SRC/bin/ps-sampler"       "$DEST/bin/ps-sampler"
 install -m 0755 "$SRC/bin/git-hook-wrapper" "$DEST/bin/git-hook-wrapper"
+install -m 0755 "$SRC/bin/build-guard"       "$DEST/bin/build-guard"
 install -m 0644 "$SRC/alloy/config.alloy"   "$DEST/alloy/config.alloy"
 ok "scripts -> $DEST/bin"
 

--- a/configs/dev-telemetry/instrument-repo.sh
+++ b/configs/dev-telemetry/instrument-repo.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# Point a repository's git hooks at the telemetry wrapper.
+#
+#   ./instrument-repo.sh /path/to/repo      instrument
+#   ./instrument-repo.sh /path/to/repo -u   remove instrumentation
+#
+# NOTHING IS COMMITTED. The only change is `git config --local core.hooksPath`,
+# which lives in .git/config — a file git does not track. The wrapper scripts
+# live outside the repository entirely. After running this, `git status` in the
+# target repo is unchanged.
+#
+# core.hooksPath is stored in the repository's common config, so a single run
+# covers every linked worktree. That sharing is also precisely why the hooks
+# contend with each other in the first place.
+
+set -euo pipefail
+
+DEST="$HOME/.config/dev-telemetry"
+REPO="${1:-$PWD}"
+MODE="${2:-install}"
+
+cd "$REPO"
+git rev-parse --git-dir >/dev/null 2>&1 || { echo "not a git repo: $REPO" >&2; exit 1; }
+COMMON=$(git rev-parse --path-format=absolute --git-common-dir)
+
+if [ "$MODE" = "-u" ] || [ "$MODE" = "--uninstall" ]; then
+    # Worktree-scoped overrides first: they win over the repo-level value, so
+    # restoring only the repo level would leave them pointing at a wrapper that
+    # is about to be deleted.
+    git worktree list --porcelain 2>/dev/null | awk '/^worktree /{print substr($0,10)}' | while read -r wt; do
+        [ -d "$wt" ] || continue
+        WT_ORIG=$(git -C "$wt" config --worktree --get telemetry.originalHooksPath 2>/dev/null || echo "")
+        [ -n "$WT_ORIG" ] || continue
+        git -C "$wt" config --worktree core.hooksPath "$WT_ORIG" 2>/dev/null || true
+        git -C "$wt" config --worktree --unset telemetry.originalHooksPath 2>/dev/null || true
+        echo "restored worktree: $wt -> $WT_ORIG"
+    done
+
+    ORIG=$(git config --local --get telemetry.originalHooksPath || echo "")
+    if [ -n "$ORIG" ]; then
+        git config --local core.hooksPath "$ORIG"
+        git config --local --unset telemetry.originalHooksPath
+        echo "restored core.hooksPath -> $ORIG"
+    else
+        git config --local --unset core.hooksPath 2>/dev/null || true
+        echo "unset core.hooksPath (there was no saved original)"
+    fi
+    exit 0
+fi
+
+[ -x "$DEST/bin/git-hook-wrapper" ] || { echo "run install.sh first" >&2; exit 1; }
+
+CURRENT=$(git config --local --get core.hooksPath || echo "")
+
+if [ "$CURRENT" = "$DEST/hooks" ]; then
+    echo "already instrumented"
+else
+    # Save whatever was there — husky v9 sets this to .husky/_ and overwriting
+    # it without a record would quietly disable the project's real hooks.
+    if [ -n "$CURRENT" ]; then
+        git config --local telemetry.originalHooksPath "$CURRENT"
+        echo "saved original core.hooksPath: $CURRENT"
+    elif [ -d .husky ]; then
+        git config --local telemetry.originalHooksPath ".husky"
+        echo "no core.hooksPath set; detected husky, saved .husky"
+    else
+        git config --local telemetry.originalHooksPath "$COMMON/hooks"
+        echo "no core.hooksPath set; saved default $COMMON/hooks"
+    fi
+    git config --local core.hooksPath "$DEST/hooks"
+    echo "core.hooksPath -> $DEST/hooks"
+fi
+
+# Worktree-scoped overrides.
+#
+# With extensions.worktreeConfig enabled, a worktree's own config.worktree can
+# carry its own core.hooksPath, and that WINS over the repo-level value set
+# above. service-dashboard-frontend has 27 such worktrees (agent-created ones
+# get an absolute path to the main clone's .husky/_). Instrumenting only the
+# repo level would silently miss every one of them — and they are precisely the
+# worktrees that push concurrently, so the gap would hide the contention this
+# whole exercise exists to measure.
+echo
+echo "worktree-scoped core.hooksPath overrides:"
+OVERRIDDEN=0
+git worktree list --porcelain 2>/dev/null | awk '/^worktree /{print substr($0,10)}' | while read -r wt; do
+    [ -d "$wt" ] || continue
+    WT_HOOKS=$(git -C "$wt" config --worktree --get core.hooksPath 2>/dev/null || echo "")
+    [ -n "$WT_HOOKS" ] || continue
+    [ "$WT_HOOKS" = "$DEST/hooks" ] && continue
+    git -C "$wt" config --worktree telemetry.originalHooksPath "$WT_HOOKS" 2>/dev/null || continue
+    git -C "$wt" config --worktree core.hooksPath "$DEST/hooks" 2>/dev/null || continue
+    OVERRIDDEN=$((OVERRIDDEN + 1))
+    echo "  redirected: $wt"
+done
+echo "  (worktrees without their own override inherit the repo-level setting)"
+
+echo
+echo "verification:"
+echo "  core.hooksPath          = $(git config --local --get core.hooksPath)"
+echo "  originalHooksPath       = $(git config --local --get telemetry.originalHooksPath)"
+printf '  working tree clean?      '
+if [ -z "$(git status --porcelain)" ]; then echo "yes — nothing was committed or staged"; else echo "NO (pre-existing changes, not from this script)"; fi

--- a/configs/dev-telemetry/launchd/com.homelab.dev-alloy.plist
+++ b/configs/dev-telemetry/launchd/com.homelab.dev-alloy.plist
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Grafana Alloy for the company MacBook Air.
+
+  Endpoints live here rather than in config.alloy so the config file stays
+  machine-independent. No secrets: the tailnet is the auth boundary, and the
+  Pi's Prometheus and Loki NodePorts carry no credentials.
+
+  StoragePath holds the remote_write WAL. That WAL is why the Pi being offline
+  is survivable — Alloy buffers to disk and replays on reconnect — so the
+  directory must be on a real disk and must not be cleaned up.
+
+  Reloading after an edit: `launchctl kickstart -k` does NOT re-read the plist,
+  it restarts from launchd's in-memory copy, so the old arguments keep running
+  while the command appears to succeed. Use bootout + bootstrap.
+
+  Installed by install.sh, which substitutes __HOME__ and __BREW__.
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.homelab.dev-alloy</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>__BREW__/bin/alloy</string>
+        <string>run</string>
+        <string>--server.http.listen-addr=127.0.0.1:12345</string>
+        <string>--storage.path=__HOME__/.local/state/dev-telemetry/alloy</string>
+        <string>__HOME__/.config/dev-telemetry/alloy/config.alloy</string>
+    </array>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PROMETHEUS_REMOTE_WRITE_URL</key>
+        <string>http://raspberrypi-5:30090/api/v1/write</string>
+        <key>LOKI_PUSH_URL</key>
+        <string>http://raspberrypi-5:30100/loki/api/v1/push</string>
+        <key>DEV_EVENTS_SPOOL</key>
+        <string>__HOME__/.local/state/dev-telemetry/events.jsonl</string>
+    </dict>
+
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+
+    <key>StandardOutPath</key>
+    <string>__HOME__/Library/Logs/dev-alloy.log</string>
+    <key>StandardErrorPath</key>
+    <string>__HOME__/Library/Logs/dev-alloy.log</string>
+
+    <key>ProcessType</key>
+    <string>Background</string>
+    <key>LowPriorityIO</key>
+    <true/>
+    <key>Nice</key>
+    <integer>5</integer>
+</dict>
+</plist>

--- a/configs/dev-telemetry/launchd/com.homelab.dev-node-exporter.plist
+++ b/configs/dev-telemetry/launchd/com.homelab.dev-node-exporter.plist
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  node_exporter for the company MacBook Air.
+
+  Deliberately NOT `brew services start node_exporter`, which is what the Mac
+  Mini uses: brew's own plist takes no arguments, and this one needs
+  --collector.textfile.directory so ps-sampler's .prom output is picked up.
+
+  Installed by install.sh, which substitutes __HOME__ and __BREW__.
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.homelab.dev-node-exporter</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>__BREW__/bin/node_exporter</string>
+        <string>--web.listen-address=127.0.0.1:9100</string>
+        <string>--collector.textfile.directory=__HOME__/.local/state/dev-telemetry/textfile</string>
+    </array>
+
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+
+    <key>StandardOutPath</key>
+    <string>__HOME__/Library/Logs/dev-node-exporter.log</string>
+    <key>StandardErrorPath</key>
+    <string>__HOME__/Library/Logs/dev-node-exporter.log</string>
+
+    <key>ProcessType</key>
+    <string>Background</string>
+    <key>LowPriorityIO</key>
+    <true/>
+    <key>Nice</key>
+    <integer>5</integer>
+</dict>
+</plist>

--- a/configs/dev-telemetry/launchd/com.homelab.dev-ps-sampler.plist
+++ b/configs/dev-telemetry/launchd/com.homelab.dev-ps-sampler.plist
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Per-process CPU/RSS sampler, every 30s.
+
+  StartInterval rather than KeepAlive: this is a run-and-exit script, so
+  KeepAlive would respawn it in a tight loop.
+
+  Nice 5 and LowPriorityIO because a monitor that competes for the resource it
+  is measuring corrupts its own measurement.
+
+  Installed by install.sh, which substitutes __HOME__.
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.homelab.dev-ps-sampler</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>__HOME__/.config/dev-telemetry/bin/ps-sampler</string>
+    </array>
+
+    <key>StartInterval</key>
+    <integer>30</integer>
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>StandardErrorPath</key>
+    <string>__HOME__/Library/Logs/dev-ps-sampler.log</string>
+
+    <key>ProcessType</key>
+    <string>Background</string>
+    <key>LowPriorityIO</key>
+    <true/>
+    <key>Nice</key>
+    <integer>5</integer>
+</dict>
+</plist>

--- a/docs/superpowers/specs/2026-08-14-company-mac-dev-telemetry-design.md
+++ b/docs/superpowers/specs/2026-08-14-company-mac-dev-telemetry-design.md
@@ -204,3 +204,32 @@ Verified from the laptop: 30090 → 302, 30100 → 404 (both reachable), and 22,
   until real contention data exists to validate the panels against.
 - **Revisit `cap=3` and the TOCTOU race** in `.husky/pre-push` once a week or
   two of data is in.
+
+## Memory baseline — 2026-08-19, before Chrome Memory Saver
+
+Recorded so the next change can be judged against something. Medians over the
+preceding 48h, not peaks: peaks are transient, the median is what a process
+actually holds while everything else needs room.
+
+| Series | Median (GB) |
+|---|---|
+| Chrome, visible browser | 2.29 |
+| `chrome-headless-shell` + `chrome-devtools-mcp` | 0.86 |
+| Notion | 1.90 |
+| swap used | 9.66 |
+| swap used, p95 | 14.39 |
+| free memory, minimum over 48h | 0.04 |
+
+Two things this changes about the obvious advice:
+
+**Chrome's Memory Saver cannot touch `chrome-headless-shell`.** That 0.86 GB
+median (2.29 GB peak) is headless Chrome spawned by the chrome-devtools MCP
+server. Memory Saver discards inactive background *tabs*; a headless instance
+has none and never idles by that definition.
+
+**Moving Notion into a Chrome tab is worth more than the process accounting
+suggests.** The desktop app is a separate Electron instance, so macOS can only
+page it to swap — there is no mechanism to hand the memory back. The same
+content in a tab becomes eligible for Memory Saver, which discards the renderer
+outright and reloads on return. On a machine whose median swap is ~10 GB,
+"reclaimable" beats "slightly smaller".

--- a/docs/superpowers/specs/2026-08-14-company-mac-dev-telemetry-design.md
+++ b/docs/superpowers/specs/2026-08-14-company-mac-dev-telemetry-design.md
@@ -139,14 +139,31 @@ No commits to any Angible repository. The only change inside one is
   27 of 81 did. Repo-level instrumentation alone would have missed exactly the
   worktrees that push concurrently.
 
+- **`loki.write` has no disk WAL by default**, unlike
+  `prometheus.remote_write`. On the Pi's first reconnect 32,623 metric samples
+  replayed while a ten-minute-old log entry had already been dropped. Now
+  enabled explicitly — the weaker default happened to cover the data that
+  cannot be reconstructed.
+- **The Pi had two independent faults producing one symptom**: `tailscaled` was
+  `systemctl disabled`, *and* its backend state was `Logged out.` Fixing only
+  the first survives until the next reboot and then fails identically.
+
+## Verification (complete)
+
+| Step | Result |
+|---|---|
+| 1. node_exporter | 631 series on `127.0.0.1:9100` |
+| 2. Alloy | ready, 0 errors |
+| 3. Transport | `up{host="angible-macbook-air"} = 1` on the Pi; all `dev_*` present |
+| 4. Log pipeline | event in Loki with exactly `{event,status,job,host}` as labels |
+| 4b. LogQL | `unwrap dur_ms` → `4210`, so durations are graphable without parsing |
+| 5. Real push | pending — happens on the next `git push` |
+
 ## Outstanding
 
-**Re-enrol the Pi on Tailscale** — `raspberrypi-5` has been offline 279 days and
-its node key has almost certainly expired, so re-auth needs a browser. Until
-then Alloy buffers to its WAL and replays on reconnect; hours are free, days
-lose data (and Loki rejects pushes older than `reject_old_samples_max_age`,
-currently 168h).
-
-Then: Tailscale ACL limiting the laptop to ports 30090/30100, and the Grafana
-dashboard — `node_load1 / 12` overlaid with hook-event annotations, plus
-`dev_vitest_workers` and `dev_hooks_running`.
+- **Tailscale ACL** limiting the laptop to ports 30090/30100 on the Pi.
+- **Grafana dashboard** — `node_load1 / 12` overlaid with hook-event
+  annotations, plus `dev_vitest_workers` and `dev_hooks_running`. Deferred
+  until real contention data exists to validate the panels against.
+- **Revisit `cap=3` and the TOCTOU race** in `.husky/pre-push` once a week or
+  two of data is in.

--- a/docs/superpowers/specs/2026-08-14-company-mac-dev-telemetry-design.md
+++ b/docs/superpowers/specs/2026-08-14-company-mac-dev-telemetry-design.md
@@ -1,0 +1,152 @@
+# Company Mac dev telemetry → homelab
+
+**Date:** 2026-08-14
+**Status:** implemented; one manual step outstanding (Tailscale on the Pi)
+
+## Problem
+
+Concurrent `pre-push` hooks across git worktrees on the company MacBook Air
+contend for CPU. Suspicion: Vitest sizes its worker pool from
+`os.availableParallelism()` and has no knowledge of other Vitest processes, so
+N concurrent pushes each claim the whole machine.
+
+Goal: permanent observability of the work machine, shipped to the homelab, good
+enough to prove where the contention is and to verify a fix afterwards.
+
+## Decisions
+
+| Question | Decision |
+|---|---|
+| Scope | Permanent monitoring, not a time-boxed probe |
+| Transport | Re-enrol the Pi on Tailscale; laptop pushes directly |
+| Events captured | git hooks, Vitest, agent sessions, top-process CPU |
+| Data egress | Raw — real branch/worktree names ship; retention bounds exposure |
+| Work-record rollup | Deferred; diagnostics first |
+| Ownership | `configs/`, not Terraform |
+
+Terraform here owns the Docker Desktop cluster and Mac Mini containers. A
+company laptop is outside that blast radius and `terraform destroy` must never
+reach it. Follows the `configs/grafana-tunnel/` precedent.
+
+## Measurements that shaped the design
+
+All taken 2026-08-14 against the live Pi and laptop.
+
+| Quantity | Value |
+|---|---|
+| Pi rootfs | 72.2 GB used / 125.3 GB, **46.7 GB free** |
+| Prometheus on-disk | 2.0 GB at 7d retention → 287 MB/day |
+| Prometheus ingest | 2,828 samples/sec, 84,802 series, ~1.18 bytes/sample |
+| Loki on-disk | 904 MB, oldest chunk **2025-10-05** → 2.9 MB/day |
+| macOS node_exporter | **758 series** (Linux is ~2x that) |
+| Laptop's added load | 50.5 samples/sec = **1.8% of existing ingest**, 5.1 MB/day |
+| Worktrees on `service-dashboard-frontend` | **81** |
+
+The laptop's contribution is negligible. What actually constrained retention
+was a k3s artefact: **42.6% of all series were duplicates.** k3s runs apiserver,
+etcd and kubelet in one binary, so the kubelet `:10250/metrics` endpoint
+re-exports `apiserver_*`/`etcd_*`/`workqueue_*` that `job=apiserver` already
+collects — 36,121 of 84,802 series. Dropping them from `job=kubelet` costs no
+capability at all.
+
+## Architecture
+
+```
+Company MacBook Air (native launchd, no Docker)      Raspberry Pi
+  node_exporter :9100 ──┐                              Prometheus :30090
+    + textfile dir      ├── Alloy ── Tailscale ──▶     Loki       :30100
+  ps-sampler (30s) ─────┘                              Grafana
+  devlog ▶ events.jsonl ┘
+```
+
+Native, not containerised: Docker Desktop on macOS runs containers in a Linux
+VM, so a containerised collector measures the VM rather than the Mac — fatal
+when the subject is real core contention.
+
+Split by data nature: **Prometheus for continuous numeric state, Loki for
+discrete events.** Only `event`, `status`, `job`, `host` become Loki labels;
+branch, worktree and durations ride in the log body where Loki does not index
+them. A branch name as a label would create a stream per feature branch.
+
+Emitters append to a spool file; they never call Alloy over HTTP. A `curl` in
+`pre-push` would put telemetry in the critical path of a real push. A single
+`printf` to an `O_APPEND` fd is atomic for short lines, which matters because
+concurrent worktrees writing at once *is* the phenomenon being measured.
+
+Vitest has no dedicated emitter. Reporting its own pool size would need either a
+committed `vitest.config.ts` change or a `--reporter` flag on an invocation the
+hook makes internally. Counting the processes from outside needs neither.
+
+## What the instrumentation found before it collected anything
+
+`service-dashboard-frontend/.husky/pre-push` **already contains a mitigation**,
+with a comment recording "~30 concurrent jsdom heaps drove this box to load 434
+and 24.5 GB of swap". It caps `VITEST_MAX_FORKS=3` when another suite is already
+running, and runs `nx affected -t lint typecheck test --parallel=3`.
+
+Two gaps remain, and they are now what the telemetry is for:
+
+1. **TOCTOU race.** `running_vitest_workers()` is evaluated once at hook start.
+   Two pushes beginning within seconds of each other both observe zero and both
+   run unbounded.
+2. **Is 3 the right cap?** Unverified. `nx --parallel=3` also multiplies pools
+   within a single push.
+
+`ps-sampler`'s `dev_vitest_workers` uses the **same regex** as the hook's
+`running_vitest_workers()`. If the metric counted something else, the dashboard
+would disagree with the mechanism it exists to explain.
+
+## Changes made
+
+**Pi** (helm, values backed up in `/tmp/pi-helm-backup/`):
+
+- `prometheus` rev 19 — `retention: 90d`, `retentionSize: 20GB`; drop
+  `(apiserver|etcd|workqueue)_.*` from `job=kubelet`. Verified: kubelet
+  `/metrics` fell from 44,098 to 3,917 samples per scrape.
+- `loki` rev 10 — `compactor.retention_enabled: true`, `retention_period: 90d`.
+
+`retentionSize` is not optional: `local-path` PVCs do not enforce quota, so
+nothing else would stop Prometheus consuming the node's free space.
+
+**Laptop** — `configs/dev-telemetry/` installed to `~/.config/dev-telemetry/`;
+three launchd agents; `core.hooksPath` redirected on
+`service-dashboard-frontend` (repo level plus 27 worktree-scoped overrides);
+Claude Code `SessionStart`/`SessionEnd` hooks added.
+
+No commits to any Angible repository. The only change inside one is
+`.git/config`, which git does not track.
+
+## Gotchas discovered
+
+- **Prometheus 3.x moved retention into the config file.** `/api/v1/status/flags`
+  reports a vestigial `1w` and the operator emits no
+  `--storage.tsdb.retention.*` argument. Check `/api/v1/status/config`. The
+  change hot-reloads; no restart.
+- **Loki's `table_manager` retention does not delete chunks** under
+  boltdb-shipper + filesystem, only index tables. `retention_deletes_enabled:
+  true` was set and 313 days of chunks had accumulated regardless.
+- **`helm --dry-run=client` silently ignores `--reuse-values`** — no cluster
+  contact means no values to reuse, and sections render empty.
+- **Alloy's `stage.labels` takes a `values` map**, unlike Promtail's YAML.
+- **`env()` is deprecated in Alloy 1.18**; `alloy validate` fails on the
+  warning. Use `sys.env()`.
+- **`launchctl bootout` returns before teardown completes**, so an immediate
+  `bootstrap` fails with `5: Input/output error`. Poll, then retry.
+- **`launchctl list | grep -q` under `set -o pipefail` gives false negatives.**
+  `grep -q` exits on first match, `launchctl` takes SIGPIPE (141), pipefail
+  promotes it. Whether it bites depends on where the match falls in the stream.
+- **`extensions.worktreeConfig`** lets a worktree override `core.hooksPath`;
+  27 of 81 did. Repo-level instrumentation alone would have missed exactly the
+  worktrees that push concurrently.
+
+## Outstanding
+
+**Re-enrol the Pi on Tailscale** — `raspberrypi-5` has been offline 279 days and
+its node key has almost certainly expired, so re-auth needs a browser. Until
+then Alloy buffers to its WAL and replays on reconnect; hours are free, days
+lose data (and Loki rejects pushes older than `reject_old_samples_max_age`,
+currently 168h).
+
+Then: Tailscale ACL limiting the laptop to ports 30090/30100, and the Grafana
+dashboard — `node_load1 / 12` overlaid with hook-event annotations, plus
+`dev_vitest_workers` and `dev_hooks_running`.

--- a/docs/superpowers/specs/2026-08-14-company-mac-dev-telemetry-design.md
+++ b/docs/superpowers/specs/2026-08-14-company-mac-dev-telemetry-design.md
@@ -159,9 +159,46 @@ No commits to any Angible repository. The only change inside one is
 | 4b. LogQL | `unwrap dur_ms` → `4210`, so durations are graphable without parsing |
 | 5. Real push | pending — happens on the next `git push` |
 
+## Tailscale ACL (done)
+
+Scoped the wrong way round at first. The ask was "the Pi should expose only a
+few ports to the tailnet"; the first draft was a tailnet-wide default-deny,
+which would have cut SSH to the laptop for no reason.
+
+The Pi was reachable on **27 ports** from every tailnet device — including 22,
+5900 (VNC), 3389 (RDP), 6443 (k3s API) and 10250 (kubelet). Now 2.
+
+Tailscale has no deny rule and no destination exclusion, so "restrict the Pi,
+leave everything else" cannot be written as an added restriction: any surviving
+`dst: *` re-opens it. The Pi has to *leave* the set the catch-all covers, which
+is what `tag:homelab` does.
+
+```jsonc
+"grants": [
+  { "src": ["autogroup:member"], "dst": ["tag:homelab"],
+    "ip": ["tcp:30090", "tcp:30100"] },
+  { "src": ["autogroup:member"], "dst": ["autogroup:member", "autogroup:internet"],
+    "ip": ["*"] },
+]
+```
+
+Everything else already has a Cloudflare Tunnel route. Tailscale carries only
+what a tunnel cannot: machine-to-machine API pushes, which Cloudflare Access
+would 302 into a login page.
+
+The tailnet uses the newer `grants` syntax; `acls` and `grants` cannot be mixed
+in one policy file. A `tests` block asserts 30090/30100 accept and 22/6443/5900
+deny, so a future regression fails the save rather than going unnoticed.
+
+Verified from the laptop: 30090 → 302, 30100 → 404 (both reachable), and 22,
+6443, 5900, 30080, 8123 all blocked.
+
 ## Outstanding
 
-- **Tailscale ACL** limiting the laptop to ports 30090/30100 on the Pi.
+- **Confirm key expiry is disabled on the Pi.** Tagging it did not clear
+  `KeyExpiry` (still 2027-02-10). Expired keys are what caused the 279-day
+  outage, so set it explicitly in the admin console rather than relying on the
+  tag.
 - **Grafana dashboard** — `node_load1 / 12` overlaid with hook-event
   annotations, plus `dev_vitest_workers` and `dev_hooks_running`. Deferred
   until real contention data exists to validate the panels against.


### PR DESCRIPTION
## What

Permanent observability for the company MacBook Air, shipped to the homelab, to
diagnose CPU contention between concurrent `pre-push` hooks across git worktrees.

Adds `configs/dev-telemetry/` (Alloy config, three launchd plists, three emitter
scripts, install + instrument scripts, README) and the design spec.

## Why this shape

- **Native, not containerised.** Docker Desktop on macOS runs containers inside a
  Linux VM, so a containerised collector reports the VM's CPU rather than the
  Mac's — fatal when the subject is real core contention.
- **`configs/`, not Terraform.** Terraform here owns the Docker Desktop cluster and
  Mac Mini containers. A company laptop is outside that blast radius.
- **Emitters append to a spool file**, never call Alloy over HTTP — telemetry must
  not sit in the critical path of a real `git push`.
- **Prometheus for state, Loki for events.** Only `event`/`status`/`job`/`host`
  become labels; branch and worktree stay in the log body.

## Measured, not assumed

| | |
|---|---|
| Laptop's added load | **1.8%** of the Pi's existing ingest (5.1 MB/day) |
| Duplicate k3s series found | **42.6%** of the whole TSDB |
| Worktrees on `service-dashboard-frontend` | **81** |
| Loki real ingest | 2.9 MB/day (oldest chunk was 313 days old) |

The laptop was never the storage concern. k3s runs apiserver, etcd and kubelet in
one binary, so `job=kubelet` re-exported 36,121 series that `job=apiserver`
already had. Dropping those from the kubelet job costs no capability.

## Pi-side changes (applied, not in this diff)

- `prometheus` rev 19 — retention 7d → 90d, `retentionSize: 20GB`, drop duplicate
  kubelet control-plane metrics. Verified: 44,098 → 3,917 samples per scrape.
- `loki` rev 10 — `compactor.retention_enabled: true`, 90d.

`retentionSize` is load-bearing: `local-path` PVCs do not enforce quota, so
nothing else would stop Prometheus eating the node's free space.

## Company repo safety

No commits to any Angible repository. The only change inside one is
`core.hooksPath` in `.git/config`, which git does not track. `instrument-repo.sh`
prints a confirmation and has an uninstall path.

## Notable finding

`.husky/pre-push` **already caps vitest** when another suite is running. Two gaps
remain, and are now what the telemetry measures: the check is evaluated once at
hook start (two pushes seconds apart both see zero), and `cap=3` has never been
validated.

## Status

Collectors verified healthy on the laptop. Transport pending the Pi rejoining the
tailnet — Alloy buffers to its WAL until then. Grafana dashboard deliberately
deferred until data exists to validate the panels against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)